### PR TITLE
Refactor / MakHoly 데이터 타입 

### DIFF
--- a/Projects/Core/Sources/Common/Componets/TasteScoreView.swift
+++ b/Projects/Core/Sources/Common/Componets/TasteScoreView.swift
@@ -46,12 +46,6 @@ public struct TasteScoreView: View {
 	let thickness: Int // 걸쭉 점수
 	let freshness: Int // 청량 점수
 	
-//	public init(type : TasteScoreViewType, taste: Taste) {
-//		self.type = type
-//		self.taste = taste
-//		self.style = TasteScoreViewStyle(scoreType: type)
-//	}
-	
 	public init(
 		type: TasteScoreViewType,
 		sweetness: Int,

--- a/Projects/Core/Sources/Common/Componets/TasteScoreView.swift
+++ b/Projects/Core/Sources/Common/Componets/TasteScoreView.swift
@@ -38,29 +38,46 @@ private struct TasteScoreViewStyle {
 
 public struct TasteScoreView: View {
 	
-	let taste: Taste
 	let type: TasteScoreViewType
 	private let style: TasteScoreViewStyle
 	
-	public init(type : TasteScoreViewType, taste: Taste) {
+	let sweetness: Int // 단맛 점수
+	let sourness: Int // 신맛 점수
+	let thickness: Int // 걸쭉 점수
+	let freshness: Int // 청량 점수
+	
+//	public init(type : TasteScoreViewType, taste: Taste) {
+//		self.type = type
+//		self.taste = taste
+//		self.style = TasteScoreViewStyle(scoreType: type)
+//	}
+	
+	public init(
+		type: TasteScoreViewType,
+		sweetness: Int,
+		sourness: Int,
+		thickness: Int, freshness: Int) {
 		self.type = type
-		self.taste = taste
 		self.style = TasteScoreViewStyle(scoreType: type)
+		self.sweetness = sweetness
+		self.sourness = sourness
+		self.thickness = thickness
+		self.freshness = freshness
 	}
 	
 	public var body: some View {
 		HStack(spacing: self.style.outerSpacing) {
-			scoreSingleView(description: "단맛", score: taste.sweetness)
-			scoreSingleView(description: "신맛", score: taste.sourness)
-			scoreSingleView(description: "걸쭉", score: taste.thickness)
-			scoreSingleView(description: "탄산", score: taste.freshness)
+			scoreSingleView(description: "단맛", score: sweetness)
+			scoreSingleView(description: "신맛", score: sourness)
+			scoreSingleView(description: "걸쭉", score: thickness)
+			scoreSingleView(description: "탄산", score: freshness)
 		}
 	}
 }
 
 extension TasteScoreView {
 	@ViewBuilder
-	func scoreSingleView(description: String, score: TasteScore) -> some View {
+	func scoreSingleView(description: String, score: Int) -> some View {
 		VStack(spacing: self.style.innerSpacing) {
 			Image(uiImage: getImage(for: self.type, score: score))
 			Text(description)
@@ -69,10 +86,10 @@ extension TasteScoreView {
 		}
 	}
 	
-	private func getImage(for type: TasteScoreViewType, score: TasteScore) -> UIImage {
+	private func getImage(for type: TasteScoreViewType, score: Int) -> UIImage {
 		switch type {
 		case .mini:
-			switch score.rawValue {
+			switch score {
 			case 0:
 				return .designSystem(.scoreMini0)!
 			case 1:
@@ -89,7 +106,7 @@ extension TasteScoreView {
 				return .designSystem(.scoreMiniNull)!
 			}
 		case .large:
-			switch score.rawValue {
+			switch score {
 			case 0:
 				return .designSystem(.scoreLarge0)!
 			case 1:

--- a/Projects/Core/Sources/Common/Extensions/String+.swift
+++ b/Projects/Core/Sources/Common/Extensions/String+.swift
@@ -1,0 +1,15 @@
+//
+//  String+.swift
+//  Core
+//
+//  Created by Eric Lee on 11/3/23.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+	public static func formattedSet(adv: Double, volume: Int, price: Int) -> String {
+		return adv.formattedAdv() + " ・ " + volume.formattedVolume() +  " ・ " + price.formattedPrice()
+	}
+}

--- a/Projects/Core/Sources/Models/MakHoly/Brewery.swift
+++ b/Projects/Core/Sources/Models/MakHoly/Brewery.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Brewery {
+public struct Brewery: Hashable {
 	public let name: String /// 양조장 이름
 	public let url: String? /// 양조장 사이트
 	public let salesURL: String? /// 판매 사이트

--- a/Projects/Core/Sources/Models/MakHoly/Brewery.swift
+++ b/Projects/Core/Sources/Models/MakHoly/Brewery.swift
@@ -13,7 +13,7 @@ public struct Brewery {
 	public let url: String? /// 양조장 사이트
 	public let salesURL: String? /// 판매 사이트
 	
-	public init(name: String, url: String?, salesURL: String) {
+	public init(name: String, url: String?, salesURL: String?) {
 		self.name = name
 		self.url = url
 		self.salesURL = salesURL

--- a/Projects/Core/Sources/Models/MakHoly/Comment.swift
+++ b/Projects/Core/Sources/Models/MakHoly/Comment.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Comment {
+public struct Comment: Identifiable, Hashable {
 	public let id: String // 코멘트 ID
 	public let makHolyId: String // 막걸리 ID
 	public let userId: String // user ID

--- a/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
@@ -8,7 +8,16 @@
 
 import Foundation
 
-public struct MakHoly {
+public struct MakHoly: Identifiable, Hashable {
+	
+	public static func == (lhs: MakHoly, rhs: MakHoly) -> Bool {
+		return lhs.id == rhs.id
+	}
+	
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(id)
+	}
+	
 	public init (
 		makHolyMini: MakHolyMini,
 		comments: [Comment],

--- a/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
@@ -46,13 +46,13 @@ public struct MakHoly {
 	public let id: String // 막걸리 ID - Seq
 	public let name: String // 막걸리 이름
 	public let imageId: String // 이미지 ID
-	public let sweetness: String // 단맛 점수
-	public let sourness: String // 신맛 점수
-	public let thickness: String // 걸쭉 점수
-	public let freshness: String // 청량 점수
-	public let price: String // 가격
-	public let volume: String // 용량
-	public let adv: String // 알코올 도수
+	public let sweetness: Int // 단맛 점수
+	public let sourness: Int // 신맛 점수
+	public let thickness: Int // 걸쭉 점수
+	public let freshness: Int // 청량 점수
+	public let price: Int // 가격
+	public let volume: Int // 용량
+	public let adv: Double // 알코올 도수
 	public let ingredients: String // 원재료
 	public let description: String // 막걸리 설명
 	

--- a/Projects/Core/Sources/Models/MakHoly/MakHolyMini.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHolyMini.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct MakHolyMini {
+public struct MakHolyMini: Identifiable, Hashable {
 	public let id: String // 막걸리 ID - Seq
 	public let name: String // 막걸리 이름
 	public let imageId: String // 이미지 ID

--- a/Projects/Core/Sources/Models/MakHoly/MakHolyMini.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHolyMini.swift
@@ -12,24 +12,24 @@ public struct MakHolyMini {
 	public let id: String // 막걸리 ID - Seq
 	public let name: String // 막걸리 이름
 	public let imageId: String // 이미지 ID
-	public let sweetness: String // 단맛 점수
-	public let sourness: String // 신맛 점수
-	public let thickness: String // 걸쭉 점수
-	public let freshness: String // 청량 점수
-	public let price: String // 가격
-	public let volume: String // 용량
-	public let adv: String // 알코올 도수
+	public let sweetness: Int // 단맛 점수
+	public let sourness: Int // 신맛 점수
+	public let thickness: Int // 걸쭉 점수
+	public let freshness: Int // 청량 점수
+	public let price: Int // 가격
+	public let volume: Int // 용량
+	public let adv: Double // 알코올 도수
 	
 	public init(id: String,
 				name: String,
 				imageId: String,
-				sweetness: String,
-				sourness: String,
-				thickness: String,
-				freshness: String,
-				price: String,
-				volume: String,
-				adv: String
+				sweetness: Int,
+				sourness: Int,
+				thickness: Int,
+				freshness: Int,
+				price: Int,
+				volume: Int,
+				adv: Double
 	) {
 		self.id = id
 		self.name = name

--- a/Projects/Core/Sources/Models/MakHoly/MakHolyTestData.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHolyTestData.swift
@@ -9,335 +9,327 @@
 import Foundation
 
 extension Award {
-	public static var mock1: Award = Award(year: 2023, name: "우리술 품평회", type: "대상")
-	public static var mock2: Award = Award(year: 2023, name: "대한민국 주류대상", type: "은상")
-	public static var mock3: Award = Award(year: 2022, name: "우리술 품평회", type: "장려상")
+	public static var mock1: Award = Award("2023 우리술 품평회 대상")
+	public static var mock2: Award = Award("2023 대한민국 주류대상 은상")
+	public static var mock3: Award = Award("2022 우리술 품평회 장려상")
 }
 
 extension Brewery {
 	public static var mockTenTen: Brewery = Brewery(
 		name: "텐텐",
-		url: "https://instagram.com/1010_appleacademy?igshid=YTQwZjQ0NmI0OA%3D%3D&utm_source=qr")
+		url: "https://instagram.com/1010_appleacademy?igshid=YTQwZjQ0NmI0OA%3D%3D&utm_source=qr", 
+		salesURL: "https://instagram.com/1010_appleacademy?igshid=YTQwZjQ0NmI0OA%3D%3D&utm_source=qr")
 	
 	public static var mockADA: Brewery = Brewery(
 		name: "애플아카데미",
-		url: "https://developeracademy.postech.ac.kr/")
+		url: "https://developeracademy.postech.ac.kr/", 
+		salesURL: "https://developeracademy.postech.ac.kr/")
 	
 	public static var mockNoURL: Brewery = Brewery(
 		name: "링크없는 양조장",
-		url: nil)
+		url: nil, 
+		salesURL: nil)
 }
 
 extension Comment {
-	public static var mockOpened: Comment = Comment(
-		description: "코멘트 남긴 내용 맛있어요",
+	
+	public static var mock1: Comment = Comment(
+		id: "c-1",
+		makHolyId: "m-1",
+		userId: "u-1",
 		isOpened: true,
-		date: "2022-10-28")
-
-	public static var mockNotOpened: Comment = Comment(
-		description: "코멘트 남긴 내용 맛 없어요",
-		isOpened: false,
+		description: "맑은내일 맛있어요!!",
 		date: "2022-10-10")
+	
+	public static var mock2: Comment = Comment(
+		id: "c-2",
+		makHolyId: "m-1",
+		userId: "u-2",
+		isOpened: false,
+		description: "너무 맛있어요 사람들이 왜 찾는지 알겠음 그렇게 또 사먹어서 안녕하세요 아무말입니다...",
+		date: "2010-10-10")
+	
+	public static var mock3: Comment = Comment(
+		id: "c-3",
+		makHolyId: "m-1",
+		userId: "u-3",
+		isOpened: false,
+		description: "우웩 별로에요.. 다신 안 먹음",
+		date: "2010-10-10")
+	
+	public static var mock4: Comment = Comment(
+		id: "c-4",
+		makHolyId: "m-1",
+		userId: "u-4",
+		isOpened: false,
+		description: "부모님께 좋은 막걸리 드리느랴 구입했습니다. 감미료가 들어간게 익숙하셔서 그런지 단맛은 덜하다고 하지만 제 입맛엔 꽤 달달한 막걸리입니다. 그만큼 단맛에 길들여지면 맛이 맹맹할 수 있습니다. ^^ 건강에 좋은 막걸리 한 잔 하시죠.",
+		date: "2010-10-10")
+	
+	public static var mock5: Comment = Comment(
+		id: "c-5",
+		makHolyId: "m-2",
+		userId: "u-5",
+		isOpened: false,
+		description: "와 역전주 진짜 맛있네요👍🏻 단맛이 나는게 신기하네요",
+		date: "2010-10-10")
+	
+	public static var mock6: Comment = Comment(
+		id: "c-6",
+		makHolyId: "m-2",
+		userId: "u-1",
+		isOpened: false,
+		description: "괜찮아요! 맛 조아요",
+		date: "2010-10-10")
 }
 
-extension Taste {
-	public static var mock1: Taste = Taste(sweetness: .five, sourness: .four, thickness: .three, freshness: .two)
-	public static var mock2: Taste = Taste(sweetness: .none, sourness: .zero, thickness: .one, freshness: .two)
+extension User {
+	
+	public static var user1: User = User(
+		id: "u-1",
+		name: "아지",
+		bookmarks: ["m-1", "m-7", "m-8", "m-9", "m-10", "m-11"],
+		likes: ["m-1", "m-2", "m-6", "m-5", "m-12", "m-13"],
+		dislikes: ["m-3", "m-4"],
+		comments: ["c-1", "c-6"])
+	
+	public static var user2: User = User(
+		id: "u-2",
+		name: "예리미",
+		bookmarks: [],
+		likes: ["m-1", "m-2", "m-3", "m-4", "m-5", "m-6", "m-7"],
+		dislikes: [],
+		comments: ["c-2"])
+	
+	public static var user3: User = User(
+		id: "u-3",
+		name: "신디",
+		bookmarks: [],
+		likes: [],
+		dislikes: ["m-1", "m-2", "m-3", "m-4", "m-5", "m-6", "m-7"],
+		comments: ["c-3"])
+	
+	public static var user4: User = User(
+		id: "u-4",
+		name: "테오",
+		bookmarks: ["m-1", "m-2", "m-3", "m-4", "m-5", "m-6", "m-7"],
+		likes: ["m-1"],
+		dislikes: [],
+		comments: ["c-4"])
+	
+	public static var user5: User = User(
+		id: "u-5",
+		name: "에릭",
+		bookmarks: ["m-1"],
+		likes: ["m-2", "m-8", "m-9", "m-10"],
+		dislikes: [],
+		comments: ["c-5"])
 }
 
-extension Review {
-	public static var mockOpened: Review = Review(name: "리이오", likeState: .like, comment: Comment.mockOpened)
-	public static var mockNotOpened: Review = Review(name: "도라", likeState: .like, comment: Comment.mockNotOpened)
+extension MakHolyMini {
+	public static var mokDatas: [MakHolyMini] = [
+		test1, test2, test3, test4, test5, test6, test7,
+		test8, test9, test10, test11, test12, test13, test14
+	]
+	
+	public static var test1: MakHolyMini = MakHolyMini(
+		id: "m-1",
+		name: "맑은내일 발효막걸리 시그니처",
+		imageId: "824",
+		sweetness: 4,
+		sourness: 4,
+		thickness: 4,
+		freshness: 4,
+		price: 9000,
+		volume: 930,
+		adv: 6.5)
+	
+	
+	public static var test2: MakHolyMini = MakHolyMini(
+		id: "m-2",
+		name: "역전주",
+		imageId: "105",
+		sweetness: 2,
+		sourness: 4,
+		thickness: 1,
+		freshness: 3,
+		price: 11000,
+		volume: 600,
+		adv: 9)
+	
+	public static var test3: MakHolyMini = MakHolyMini(
+		id: "m-3",
+		name: "1000억 유산균 막걸리",
+		imageId: "170",
+		sweetness: 3,
+		sourness: 5,
+		thickness: 3,
+		freshness: 5,
+		price: 3200,
+		volume: 750,
+		adv: 5)
+	
+	public static var test4: MakHolyMini = MakHolyMini(
+		id: "m-4",
+		name: "별산막걸리",
+		imageId: "124",
+		sweetness: 4,
+		sourness: 4,
+		thickness: 3,
+		freshness: -1,
+		price: 11000,
+		volume: 800,
+		adv: 6.5)
+	
+	public static var test5: MakHolyMini = MakHolyMini(
+		id: "m-5",
+		name: "배꽃 필 무렵",
+		imageId: "1107",
+		sweetness: 1,
+		sourness: 2,
+		thickness: 3,
+		freshness: 1,
+		price: 15800,
+		volume: 140,
+		adv: 9)
+	
+	public static var test6: MakHolyMini = MakHolyMini(
+		id: "m-6",
+		name: "이화백주 순탁주",
+		imageId: "110",
+		sweetness: 4,
+		sourness: 3,
+		thickness: 4,
+		freshness: 3,
+		price: 14400,
+		volume: 940,
+		adv: 6)
+	
+	public static var test7: MakHolyMini = MakHolyMini(
+		id: "m-7",
+		name: "이화주",
+		imageId: "1108",
+		sweetness: 4,
+		sourness: 2,
+		thickness: 4,
+		freshness: 3,
+		price: 12350,
+		volume: 120,
+		adv: 8.5)
+	
+	public static var test8: MakHolyMini = MakHolyMini(
+		id: "m-8",
+		name: "우곡생주",
+		imageId: "92",
+		sweetness: 4,
+		sourness: 2,
+		thickness: 5,
+		freshness: 2,
+		price: 10000,
+		volume: 750,
+		adv: 10)
+	
+	public static var test9: MakHolyMini = MakHolyMini(
+		id: "m-9",
+		name: "장수 생막걸리",
+		imageId: "141",
+		sweetness: 2,
+		sourness: 3,
+		thickness: 3,
+		freshness: 3,
+		price: 1500,
+		volume: 750,
+		adv: 6)
+	
+	public static var test10: MakHolyMini = MakHolyMini(
+		id: "m-10",
+		name: "느린마을막걸리 봄",
+		imageId: "221",
+		sweetness: 4,
+		sourness: 1,
+		thickness: -1,
+		freshness: 2,
+		price: 3400,
+		volume: 750,
+		adv: 6)
+	
+	public static var test11: MakHolyMini = MakHolyMini(
+		id: "m-11",
+		name: "정감생막걸리",
+		imageId: "799",
+		sweetness: 2,
+		sourness: 3,
+		thickness: 5,
+		freshness: 2,
+		price: 6000,
+		volume: 750,
+		adv: 6)
+	
+	public static var test12: MakHolyMini = MakHolyMini(
+		id: "m-12",
+		name: "맑은내일 스파클링 막걸리 시그니처",
+		imageId: "824",
+		sweetness: 4,
+		sourness: 4,
+		thickness: 4,
+		freshness: 4,
+		price: 9000,
+		volume: 930,
+		adv: 6.5)
+	
+	public static var test13: MakHolyMini = MakHolyMini(
+		id: "m-13",
+		name: "본",
+		imageId: "E4",
+		sweetness: -1,
+		sourness: -1,
+		thickness: -1,
+		freshness: 1,
+		price: 45000,
+		volume: 375,
+		adv: 17)
+	
+	public static var test14: MakHolyMini = MakHolyMini(
+		id: "m-14",
+		name: "인천 생 소성주",
+		imageId: "1068",
+		sweetness: 1,
+		sourness: 2,
+		thickness: 2,
+		freshness: 1,
+		price: 120,
+		volume: 750,
+		adv: 6
+	)
 }
 
 extension MakHoly {
 	public static var test1: MakHoly = MakHoly(
-		id: "test1-ID",
-		name: "텐텐 막걸리",
-		imageURL: "https://thesool.com/common/imageView.do?targetId=PR00000943&targetNm=PRODUCT",
-		adv: 10,
-		volume: 5000,
-		price: 10000,
-		taste: Taste.mock1,
-		description: "우주 최강 텐텐 팀의 텐텐 막걸리입니다. 멋있고, 귀엽고, 섹시하고, 이쁘고, 깜찍하고, 알레강스하며 귵합니다.",
-		awards: [Award.mock1, Award.mock2, Award.mock3],
-		ingredients: ["쌀(국내산/무농약)", "효모", "누룩(밀/국내산)", "정제수"],
-		salesURL: "https://instagram.com/1010_appleacademy?igshid=YTQwZjQ0NmI0OA%3D%3D&utm_source=qr",
-		brewery: Brewery.mockTenTen,
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [Review.mockOpened, Review.mockNotOpened])
+		makHolyMini: MakHolyMini.test1,
+		comments: [Comment.mock1, Comment.mock2, Comment.mock3, Comment.mock4],
+		awards: [Award("2022 대한민국 주류대상 대상")],
+		likeUsers: ["u-1", "u-2", "u-4"],
+		dislikeUsers: ["u-3"],
+		bookmarkUsers: ["u-1", "u-4", "u-5"],
+		ingredients: "정제수, 쌀, 누룩(밀), 아밀라아제(효소제), 아스파탐",
+		description: "프리미엄 막걸리 맑은내일 발효막걸리 Signature 는 한국 전통 누룩으로 빚어 걸쭉하면서 진하고 누룩 함량이 높아 부드럽고 깊은 향이 일품이다. 묵직한 누룩맛과 부드러운 텍스처, 유산균이 빚어내는 오묘한 산미와 단맛의 조화가 특징이다.  제품이 완성된 후에도 효모는 발효되기 때문에 시간의 경과에 따라 다른 맛과 느낌으로 즐길 수 있다.",
+		brewery: Brewery(
+			name: "우포의 아침",
+			url: "https://www.good-tomorrow.co.kr",
+			salesURL: "https://www.good-tomorrow.co.kr/shop/item.php?it_id=1646725796")
+	)
 	
 	public static var test2: MakHoly = MakHoly(
-		id: "test2-ID",
-		name: "애플 막걸리",
-		imageURL: "https://thesool.com/common/imageView.do?targetId=PR00000943&targetNm=PRODUCT",
-		adv: 10.10,
-		volume: 650,
-		price: 10000,
-		taste: Taste.mock2,
-		description: "마시면 월클되는 막걸리",
-		awards: [Award.mock1, Award.mock2, Award.mock3],
-		ingredients: ["쌀(국내산/무농약)", "효모", "누룩(밀/국내산)", "정제수"],
-		salesURL: "https://developeracademy.postech.ac.kr/",
-		brewery: Brewery.mockADA,
-		myLikeState: .like,
-		isBookMarked: true,
-		myComment: Comment.mockOpened,
-		reviews: [Review.mockOpened, Review.mockNotOpened])
-	
-	public static var mockMakHolies: [MakHoly] = [mock1, mock2, mock3, mock4, mock5, mock6, mock7, mock8, mock9, mock10, mock11, mock12, mock13, mock14]
-	
-	public static var mock1: MakHoly = MakHoly(
-		id: "824",
-		name: "맑은내일 발효막걸리 시그니처",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/824.png?w=118&h=244&t=outside",
-		adv: 6.5,
-		volume: 930,
-		price: 9000,
-		taste: Taste(sweetness: .four, sourness: .four, thickness: .four, freshness: .four),
-		description: "프리미엄 막걸리 맑은내일 발효막걸리 Signature 는 한국 전통 누룩으로 빚어 걸쭉하면서 진하고 누룩 함량이 높아 부드럽고 깊은 향이 일품이다. 묵직한 누룩맛과 부드러운 텍스처, 유산균이 빚어내는 오묘한 산미와 단맛의 조화가 특징이다.  제품이 완성된 후에도 효모는 발효되기 때문에 시간의 경과에 따라 다른 맛과 느낌으로 즐길 수 있다.",
-		awards: [Award(year: 2022, name: "대한민국 주류대상", type: "대상")],
-		ingredients: ["정제수", "쌀", "누룩(밀)", "아밀라아제(효소제)", "아스파탐"],
-		salesURL: "https://www.good-tomorrow.co.kr/shop/item.php?it_id=1646725796",
-		brewery: Brewery(name: "우포의 아침", url: "https://www.good-tomorrow.co.kr"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock2: MakHoly = MakHoly(
-		id: "105",
-		name: "역전주",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/105.png?w=118&h=244&t=outside",
-		adv: 9,
-		volume: 600,
-		price: 11000,
-		taste: Taste(sweetness: .two, sourness: .four, thickness: .one, freshness: .three),
+		makHolyMini: MakHolyMini.test2,
+		comments: [Comment.mock5, Comment.mock6],
+		awards: [Award("2021 대한민국 주류대상 대상")],
+		likeUsers: ["u-1", "u-2", "u-5"],
+		dislikeUsers: ["u-3"],
+		bookmarkUsers: ["u-4"],
+		ingredients: "정제수, 멥쌀(국내산), 찹쌀(국내산), 누룩",
 		description: "역전주는 역전회관에서 자체 기획 및 전통방식으로 소량 생산하는 private brand 로 100% 국내산 쌀과 찹쌀, 누룩, 물만으로 빚어 저온 발효와 숙성을 거쳐 쌀 본연의 은은한 단맛과 산미가 특징이다. 인공감미료나 첨가물을 넣지 않고 약 100일간의 자연발효과 저온숙성을 거치면서 계절의 온도와 쌀의 풍미가 오롯이 담긴 막걸리다. 알콜도수는 9도로 음식과 함께 즐기기에 좋고, 목넘김이 부드러운 것이 특징이다.",
-		awards: [Award(year: 2021, name: "대한민국 주류대상", type: "대상")],
-		ingredients: ["정제수", "멥쌀", "찹쌀(국내산)", "누룩"],
-		salesURL: nil,
-		brewery: Brewery(name: "국순당", url: "http://drink.ksdb.co.kr/"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock3: MakHoly = MakHoly(
-		id: "170",
-		name: "1000억 유산균 막걸리",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/170.png?w=118&h=244&t=outside",
-		adv: 5,
-		volume: 750,
-		price: 3200,
-		taste: Taste(sweetness: .three, sourness: .five, thickness: .three, freshness: .five),
-		description: "1000억 유산균 막걸리는 국순당이 최초로 선보인 유산균 강화 막걸리다. 식물성 유산균이 막걸리 한 병(750mL)에 1000억 마리 이상이 들어 있다. 시중에 판매되는 일반 생막걸리 한 병(자사 생막걸리 750mL 기준)당 1억 마리 가량의 유산균이 들어 있는 것과 비교하면 약 1000배 많이 들어있고, 일반 유산균음료 보다 약 100배 많이 들어 있다.",
-		awards: [Award(year: 2021, name: "대한민국 주류대상", type: "대상"), Award(year: 2020, name: "대한민국 주류대상", type: "대상")],
-		ingredients: ["정제수", "멥쌀(국내산)", "기타과당", "국(밀)", "효모", "젖산"],
-		salesURL: nil,
-		brewery: Brewery(name: "역전양조장", url: "www.yukjeon.com"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock4: MakHoly = MakHoly(
-		id: "124",
-		name: "별산막걸리",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/124.png?w=118&h=244&t=outside",
-		adv: 6.5,
-		volume: 800,
-		price: 11000,
-		taste: Taste(sweetness: .four, sourness: .four, thickness: .three, freshness: .none),
-		description: "별산막걸리는 경기도 양주의 단단한 쌀을 사용하고 어느 누구도 시도하지 않은 특별한 발효균주를 이용하여 만든 프리미엄 막걸리다. 맛과 품질에서 우수함을 인정 받은 결과 대한민국주류대상  3회 수상 경력의 귀한 막걸리.다",
-		awards: [Award(year: 2020, name: "대한민국 주류대상", type: "대상"), Award(year: 2020, name: "우리술 품평회", type: "최우수상")],
-		ingredients: ["정제수", "쌀", "입국", "당류가공품", "종국", "효모"],
-		salesURL: nil,
-		brewery: Brewery(name: "양주도가", url: "https://smartstore.naver.com/yangjudoga"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock5: MakHoly = MakHoly(
-		id: "1107",
-		name: "배꽃 필 무렵",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/1107.png?w=118&h=244&t=outside",
-		adv: 9,
-		volume: 140,
-		price: 15800,
-		taste: Taste(sweetness: .one, sourness: .two, thickness: .three, freshness: .one),
-		description: "‘배꽃 필 무렵’은 이화주다. 이화주는 ‘배꽃 필 때 빚는다’ 하여 이화주(梨花酒)라고 불린다. 이화주는 고려시대 때부터 빚어졌던 술로, 빛깔이 희고 된죽과 같아 숟가락으로 떠먹기도 하고, 찬물에 타서 마시기도 한다.",
-		awards: [Award(year: 2020, name: "우리술 품평회", type: "최우상")],
-		ingredients: ["쌀", "누룩", "잣나무잎", "정제수"],
-		salesURL: nil,
-		brewery: Brewery(name: "예술주조", url: "http://www.ye-sul.co.kr"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock6: MakHoly = MakHoly(
-		id: "110",
-		name: "이화백주 순탁주",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/110.png?w=118&h=244&t=outside",
-		adv: 6,
-		volume: 940,
-		price: 14400,
-		taste: Taste(sweetness: .four, sourness: .three, thickness: .four, freshness: .three),
-		description: "국내산 햅쌀 100%와 전통누룩으로 빚어 15일간 저온에서 자연 발효했다. 첨가물을 넣지 않고 전통방식으로 빚어 부드러우면서도 풍미가 뛰어나다. 탄산의 경쾌함과 레몬 맛과 같은 시트러스 계열의 맛과 향이 느껴진다.",
-		awards: [Award(year: 2019, name: "대한민국 주류대상", type: "대상")],
-		ingredients: ["정제수", "쌀", "누룩(밀함유)", "물엿", "설탕", "아스파탐"],
-		salesURL: nil,
-		brewery: Brewery(name: "이화백주", url: "https://www.facebook.com/ehwayangzo/"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock7: MakHoly = MakHoly(
-		id: "1108",
-		name: "이화주",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/1108.png?w=118&h=244&t=outside",
-		adv: 8.5,
-		volume: 120,
-		price: 12350,
-		taste: Taste(sweetness: .four, sourness: .two, thickness: .four, freshness: .three),
-		description: "이화주는 고려시대 때부터 빚어졌던 술로써 물을 거의 사용하지 않는 다는 것이 가장 큰 특징이며 농축 요구르트와 같은 된 죽 형태이고 달달한 맛과 독특한 향이 특징입니다.",
-		awards: [Award(year: 2022, name: "우리술 품평회", type: "대상"), Award(year: 2019, name: "대한민국 주류대상", type: "대상"), Award(year: 2018, name: "대한민국 주류대상", type: "대상"), Award(year: 2017, name: "대한민국 주류대상", type: "대상"), Award(year: 2016, name: "대한민국 주류대상", type: "대상")],
-		ingredients: ["쌀", "쌀누룩", "정제수"],
-		salesURL: nil,
-		brewery: Brewery(name: "양주골이가", url: "http://egaju.co.kr/"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock8: MakHoly = MakHoly(
-		id: "92",
-		name: "우곡생주",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/92.png?w=118&h=244&t=outside",
-		adv: 10,
-		volume: 750,
-		price: 10000,
-		taste: Taste(sweetness: .four, sourness: .two, thickness: .five, freshness: .two),
-		description: "우곡 생주는 일생을 전통주를 위해 헌신한 고 배상면 회장의 마지막 역작을 바탕으로 딸인 배혜정 대표가 아버지의 이념을 계승한 제품이다. 막걸리에 첨가물을 일절 사용하지 않아 인위적은 맛을 내지 않고 쌀 고유의 맛으로 빚은 막걸리이다. 일반 탁주와 달리 가수를 거의 하지않아 바디감이 휼륭하고 작은량의 생산만 되는 귀한 술이며 농후한 원주의 맛을 느낄 수 있다.",
-		awards: [Award(year: 2019, name: "우리술 품평회", type: "대상")],
-		ingredients: ["정제수", "쌀", "효모", "국(조효소제, 정제효소)", "젖산(산도조절제)"],
-		salesURL: nil,
-		brewery: Brewery(name: "배혜정도가", url: "http://www.baedoga.co.kr/"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock9: MakHoly = MakHoly(
-		id: "141",
-		name: "장수 생막걸리",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/141.png?w=118&h=244&t=outside",
-		adv: 6,
-		volume: 750,
-		price: 1500,
-		taste: Taste(sweetness: .two, sourness: .three, thickness: .three, freshness: .three),
-		description: "국내산 백미를 사용해 장기저온숙성 방식으로 만들어져 영양이 풍부하고 자연발효에 의한 탄산과 어울려 감칠맛과 청량감이 일품입니다. 또한, 트림과 숙취도 거의 없어 오랜 시간 동안 사랑을 받고 있습니다.",
-		awards: [Award(year: 2020, name: "대한민국 주류대상", type: "대상"), Award(year: 2019, name: "우리술 품평회", type: "우수상")],
-		ingredients: ["쌀(백미)", "팽화미", "입국", "말토올리고당", "곡자", "아스파탐(감미료)", "구연산", "기타가공품(보울라디 효모)", "정제수"],
-		salesURL: nil,
-		brewery: Brewery(name: "서울장수주식회사", url: "https://seouljangsu.modoo.at/"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock10: MakHoly = MakHoly(
-		id: "221",
-		name: "느린마을막걸리 봄",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/221.png?w=118&h=244&t=outside",
-		adv: 6,
-		volume: 750,
-		price: 3400,
-		taste: Taste(sweetness: .four, sourness: .one, thickness: .none, freshness: .two),
-		description: "느린 마을 막걸리의 1~5일차 봄맛으로 달콤한 향과 부드러운 목넘김이 특징이다.",
-		awards: [Award(year: 2017, name: "우리술 품평회", type: "최우수상"), Award(year: 2014, name: "우리술 품평회", type: "우수상")],
-		ingredients: ["정제수", "쌀가루", "입국(쌀입국)", "조효소제", "건조효모", "정제효소제"],
-		salesURL: nil,
-		brewery: Brewery(name: "배상면주가", url: "https://www.soolsool.co.kr/"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock11: MakHoly = MakHoly(
-		id: "799",
-		name: "정감생막걸리",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/799.png?w=118&h=244&t=outside",
-		adv: 6,
-		volume: 750,
-		price: 6000,
-		taste: Taste(sweetness: .two, sourness: .three, thickness: .five, freshness: .two),
-		description: "깊은 산골 청정수와 신토불이 하동산 쌀과 찹쌀 그리고 우리밀 누룩으로 장기 저온에서 발효숙성하여 장인의 정성이 빚어낸 한 잔에 오미를 담아 달빛같은 감성이 살아 숨쉬는 전통 곡주이다.",
-		awards: [],
-		ingredients: ["정제수", "쌀(국내산, 수입산)", "밀가루(수입산)", "입국", "발효미강(미강)", "곡자(누룩)", "조효소제(밀)", "사카린나트륨(감미료)", "젖산", "식품첨가물혼합제제(충무정제효소, 송천효모)"],
-		salesURL: nil,
-		brewery: Brewery(name: "악양주조", url: "https://smartstore.naver.com/akyangjujo"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock12: MakHoly = MakHoly(
-		id: "824",
-		name: "맑은내일 스파클링 막걸리 시그니처",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/824.png?w=118&h=244&t=outside",
-		adv: 6.5,
-		volume: 930,
-		price: 9000,
-		taste: Taste(sweetness: .four, sourness: .four, thickness: .four, freshness: .four),
-		description: "프리미엄 막걸리 맑은내일 발효막걸리 Signature 는 한국 전통 누룩으로 빚어 걸쭉하면서 진하고 누룩 함량이 높아 부드럽고 깊은 향이 일품이다. 묵직한 누룩맛과 부드러운 텍스처, 유산균이 빚어내는 오묘한 산미와 단맛의 조화가 특징이다.  제품이 완성된 후에도 효모는 발효되기 때문에 시간의 경과에 따라 다른 맛과 느낌으로 즐길 수 있다.",
-		awards: [Award(year: 2022, name: "대한민국 주류대상", type: "대상")],
-		ingredients: ["정제수", "쌀", "누룩(밀)", "아밀라아제(효소제)", "아스파탐"],
-		salesURL: nil,
-		brewery: Brewery(name: "우포의아침", url: "http://www.good-tomorrow.co.kr"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock13: MakHoly = MakHoly(
-		id: "E4",
-		name: "본",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/E4.png?w=118&h=244&t=outside",
-		adv: 17,
-		volume: 375,
-		price: 45000,
-		taste: Taste(sweetness: .none, sourness: .none, thickness: .none, freshness: .one),
-		description: "자연만이 주는 재료들이 시간(숙성)을 빌어 내는 향기. 달콤한 바나나향과 향긋한 참외 향이 주는 신비로운 첫 만남! 혀 끝에 닿아 밀려오는 향기 품은 달콤한은 혀의 전부를 감미롭게 도는 듯 싶다가, 이내 거친 17% 풍미의 여운을 남기고는 목 넘어 깊숙한 곳으로 사라지고 만다.",
-		awards: [Award(year: 2023, name: "우리술 품평회", type: "대통령상")],
-		ingredients: ["국", "쌀", "효모", "정제수"],
-		salesURL: nil,
-		brewery: Brewery(name: "두루미 양조장", url: "http://xn--hu1b40gh1c27n9rc18a.kr/index.html"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
-	
-	public static var mock14: MakHoly = MakHoly(
-		id: "1068",
-		name: "인천 생 소성주",
-		imageURL: "https://d2hyndjmu9mjcd.cloudfront.net/images/1068.png?w=118&h=244&t=outside",
-		adv: 6,
-		volume: 750,
-		price: 1200,
-		taste: Taste(sweetness: .one, sourness: .two, thickness: .two, freshness: .one),
-		description: "기존의 막걸리의 이미지가 남성적이고 투박하며 거칠고 탁한 맛이었다면 생소성주는 여성들과 젊은층도 선호할 수 있도록 숙성시간과 담금횟수를 늘려 부드럽고 톡 쏘는 청량감이 느껴져 누구나 부담없이 마실수 있도록 하였다.인천의 통일신라 시대 이름인 소성현에서 이름이 유래한 생소성주는 80년 넘게 막걸리를 빚으며 업계최초로 쌀로 만든 막걸리를 만들었고, 인천지역 최고의 점유률을 자랑하는 대표 막걸리이다.또한 포장에는 소비자들에게 즐길거리를 제공하기 위해 12간지 동물을 그려넣어 막걸리를 마시면서 재미있는 대화의 소재가 될수 있도록 하였다.생소성주는 성인이라면 누구나 마음편하게 마실수 있도록 부담없는 가격으로 공급해야 한다는 마인드를 바탕으로 지속적인 연구와 개발을 끊임없이 하고 있다1990년 업계 최초로 쌀 막걸리를 출시한 인천탁주. 90년대 초부터 수출을 시작하고 92년 우수 포장선정 국세청장의 표창까지 받은 유서 깊은 양조으로, 인천지역 막걸리 시장의 큰손으로 자리매김하고 있다. 지난 1974년 인천지역의 11개 양조장의 합병으로 만들어져 72년간의 오랜 경험을 바탕으로 인천의 자부심을 가지고 막걸리를 빚고 있다.생 소성주는 숙성시간과 담금 횟수를 늘려 부드럽고 톡 쏘는 탄산의 상쾌한 청량감이 느껴지며, 특유의 감칠맛이 매력적이다.",
-		awards: [],
-		ingredients: ["정제수", "쌀(멤쌀)", "팽화미", "올리고당", "곡자(밀함유)", "효모(우유함유)", "종국", "정제효소제", "아스파탐", "구연산"],
-		salesURL: nil,
-		brewery: Brewery(name: "인천탁주", url: "http://sosungju.modoo.at/"),
-		myLikeState: .none,
-		isBookMarked: false,
-		myComment: nil,
-		reviews: [])
+		brewery: Brewery(
+			name: "국순당",
+			url: "http://drink.ksdb.co.kr/",
+			salesURL: nil)
+	)
 }

--- a/Projects/Core/Sources/Models/MakHoly/MakHolyTestData.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHolyTestData.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 extension Award {
+	public static var mockDatas: [Award] = [Award.mock1, Award.mock2, Award.mock3]
+	
 	public static var mock1: Award = Award("2023 우리술 품평회 대상")
 	public static var mock2: Award = Award("2023 대한민국 주류대상 은상")
 	public static var mock3: Award = Award("2022 우리술 품평회 장려상")
@@ -303,6 +305,8 @@ extension MakHolyMini {
 }
 
 extension MakHoly {
+	public static var mockDatas: [MakHoly] = [test1, test2]
+	
 	public static var test1: MakHoly = MakHoly(
 		makHolyMini: MakHolyMini.test1,
 		comments: [Comment.mock1, Comment.mock2, Comment.mock3, Comment.mock4],

--- a/Projects/Core/Sources/Network/Response/MakgeolliInfoResponse.swift
+++ b/Projects/Core/Sources/Network/Response/MakgeolliInfoResponse.swift
@@ -22,27 +22,7 @@ public struct MakgeolliDetail: Codable {
 	public let attributes: [MakgeolliAttribute]?
 	
 	public var toEntity: MakHoly {
-		
-		let awards = [Award]
-		
-		return MakHoly(id: String(makSeq ?? 0),
-					   name: makName ?? "",
-					   imageURL: makImageNumber ?? "",
-					   adv: attributes?.first?.mainDetail?.first?.makAlcoholPercentage ?? 0.0,
-					   volume: attributes?.first?.mainDetail?.first?.makVolume ?? 0,
-					   price: attributes?.first?.mainDetail?.first?.makPrice ?? 0,
-					   taste: Taste(sweetness: .one, sourness: .five, thickness: .four, freshness: .one), // 못함
-					   description: attributes?.description ?? "",
-					   awards: [Award(year: 0, name: "", type: "")], // 못함
-					   ingredients: (attributes?.first?.makRaw?.components(separatedBy: ", ")) ?? [],
-					   salesURL: attributes?.first?.breweryInfo?.first?.makSalesLink,
-					   brewery: Brewery(name: attributes?.first?.breweryInfo?.first?.makBrewery ?? "",
-										url: attributes?.first?.breweryInfo?.first?.makBreweryLink ?? ""),
-					   myLikeState: LikeState.dislike,
-					   isBookMarked: false,
-					   myComment: Comment.init(description: "", isOpened: false, date: ""),
-					   reviews: [Review(name: "", likeState: LikeState.dislike,
-										comment: Comment(description: "", isOpened: false, date: ""))])
+		return MakHoly.test1
 	}
 }
 

--- a/Projects/FeatureCategory/Scene/CategoryViewModel.swift
+++ b/Projects/FeatureCategory/Scene/CategoryViewModel.swift
@@ -10,8 +10,8 @@ import Foundation
 import Core
 
 final class CategoryViewModel: ObservableObject {
-	@Published var fetchLoading = true
-	@Published var makgeollis: [MakgeolliItem] = []
+	@Published var fetchLoading = false
+	@Published var makHolys: [MakHolyMini] = MakHolyMini.mokDatas
 	
 	let makgeolliRepository: DefaultMakgeolliRepository
 	
@@ -26,11 +26,11 @@ final class CategoryViewModel: ObservableObject {
 		fetchLoading = true
 		Task {
 			do {
-				let stringCategory = categories.map { $0.rawValue }
-				let response = try await makgeolliRepository.fetchMakgeolliList(
-					categories: stringCategory.isEmpty ? nil : stringCategory
-				)
-				makgeollis = (response.result?.contents)!
+//				let stringCategory = categories.map { $0.rawValue }
+//				let response = try await makgeolliRepository.fetchMakgeolliList(
+//					categories: stringCategory.isEmpty ? nil : stringCategory
+//				)
+//				makgeollis = (response.result?.contents)!
 				fetchLoading = false
 			} catch {
 				// error

--- a/Projects/FeatureCategory/Scene/MakgeolliInformation/MakgeolliInfoContentView.swift
+++ b/Projects/FeatureCategory/Scene/MakgeolliInformation/MakgeolliInfoContentView.swift
@@ -11,14 +11,11 @@ import Core
 import DesignSystem
 
 struct MakgeolliInfoContentView: View {
-	let makgeolliData: MockMakgeolliModel
+	let makHoly: MakHolyMini
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 0) {
-			Text(makgeolliData.breweryName)
-				.font(.system(size: 16, weight: .bold))
-				.padding(.bottom, 2)
-			Text(makgeolliData.name)
+			Text(makHoly.name)
 				.font(.system(size: 20, weight: .bold))
 				.foregroundColor(.white)
 
@@ -28,7 +25,7 @@ struct MakgeolliInfoContentView: View {
 			HStack(spacing: 10) {
 				Text("도수")
 					.font(.system(size: 16, weight: .regular))
-				Text("\(String(format: "%.1f", makgeolliData.alcoholContent))%")
+				Text("\(String(format: "%.1f", makHoly.adv))%")
 					.font(.system(size: 16, weight: .regular))
 					.foregroundColor(.white)
 			}
@@ -36,7 +33,7 @@ struct MakgeolliInfoContentView: View {
 			HStack(spacing: 10) {
 				Text("용량")
 					.font(.system(size: 16, weight: .regular))
-				Text("\(makgeolliData.capacity)ml")
+				Text("\(makHoly.volume)ml")
 					.font(.system(size: 16, weight: .regular))
 					.foregroundColor(.white)
 			}
@@ -44,7 +41,7 @@ struct MakgeolliInfoContentView: View {
 			HStack(spacing: 10) {
 				Text("가격")
 					.font(.system(size: 16, weight: .regular))
-				Text("\(makgeolliData.price)원")
+				Text("\(makHoly.price)원")
 					.font(.system(size: 16, weight: .regular))
 					.foregroundColor(.white)
 			}

--- a/Projects/FeatureCategory/Scene/MakgeolliInformation/MakgeolliInfoSingleView.swift
+++ b/Projects/FeatureCategory/Scene/MakgeolliInformation/MakgeolliInfoSingleView.swift
@@ -12,7 +12,7 @@ import DesignSystem
 import FeatureInformation
 
 struct MakgeolliInfoSingleView: View {
-	let makgeolliData: MakgeolliItem
+	let makHoly: MakHolyMini
 	
 	var body: some View {
 		NavigationLink {
@@ -29,16 +29,16 @@ struct MakgeolliInfoSingleView: View {
 								.aspectRatio(contentMode: .fit)
 								.padding(.bottom, 18)
 							
-							TasteScoreView(type: .mini, taste: Taste(sweetness: .one, sourness: .two, thickness: .three, freshness: .four))
+							TasteScoreView(type: .mini, sweetness: makHoly.sweetness, sourness: makHoly.sourness, thickness: makHoly.thickness, freshness: makHoly.freshness)
 						}
 						.padding(.vertical, 32)
 					}
-				Text(makgeolliData.makName!)
+				Text(makHoly.name)
 					.lineLimit(1)
 					.font(.style(.SF14R))
 					.padding(.top, 12)
 				
-				Text("\(String(format: "%.1f", makgeolliData.makAlcoholPercentage!))도, \(makgeolliData.makVolume!)ml, \(makgeolliData.makPrice!)원")
+				Text(String.formattedSet(adv: makHoly.adv, volume: makHoly.volume, price: makHoly.price))
 					.font(.style(.SF12R))
 					.foregroundColor(Color(uiColor: .designSystem(.w50)!))
 					.padding(.top, 2)

--- a/Projects/FeatureCategory/Scene/MakgeolliInformation/MakgeolliInfoView.swift
+++ b/Projects/FeatureCategory/Scene/MakgeolliInformation/MakgeolliInfoView.swift
@@ -31,8 +31,8 @@ struct MakgeolliInfoView: View {
 				.padding(.bottom, 16)
 			}
 			LazyVGrid(columns: columns) {
-				ForEach(viewModel.makgeollis, id: \.self) { data in
-					MakgeolliInfoSingleView(makgeolliData: data)
+				ForEach(viewModel.makHolys, id: \.self) { data in
+					MakgeolliInfoSingleView(makHoly: data)
 						.padding(.horizontal, 8)
 						.padding(.bottom, 30)
 				}

--- a/Projects/FeatureHome/Scene/HomeViewModel.swift
+++ b/Projects/FeatureHome/Scene/HomeViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import Core
 
 final class HomeViewModel: ObservableObject {
-	@Published var newItems: [MakgeolliItem] = []
+	@Published var newItems: [MakHolyMini] = MakHolyMini.mokDatas
 	@Published var fetchLoading = true
 	
 	let makgeolliRepository: DefaultMakgeolliRepository
@@ -25,8 +25,8 @@ final class HomeViewModel: ObservableObject {
 	func fetchNewMakgeolli() {
 		Task {
 			do {
-				let response = try await makgeolliRepository.fetchMakgeolliList()
-				newItems = (response.result?.contents)!
+//				let response = try await makgeolliRepository.fetchMakgeolliList()
+//				newItems = (response.result?.contents)!
 				fetchLoading = false
 			} catch {
 				// error

--- a/Projects/FeatureHome/Scene/NewItem/NewItemSingleView.swift
+++ b/Projects/FeatureHome/Scene/NewItem/NewItemSingleView.swift
@@ -11,7 +11,7 @@ import Core
 import DesignSystem
 
 struct NewItemSingleView: View {
-	let item: MakgeolliItem
+	let item: MakHolyMini
 	
 	var body: some View {
 		NavigationLink {
@@ -25,17 +25,17 @@ struct NewItemSingleView: View {
 						Rectangle()
 							.fill(Color(uiColor: .designSystem(.goldenyellow)!))
 						
-						Text(item.makName!)
+						Text(item.name)
 							.font(.style(.SF12R))
 							.lineLimit(1)
 						
-						TasteGraphView(steps: Int(item.makTasteSweet ?? 0))
+						TasteGraphView(steps: Int(item.sweetness))
 							.frame(height: 4)
-						TasteGraphView(steps: Int(item.makTasteSour ?? 0))
+						TasteGraphView(steps: Int(item.sourness))
 							.frame(height: 4)
-						TasteGraphView(steps: Int(item.makTasteThick ?? 0))
+						TasteGraphView(steps: Int(item.thickness))
 							.frame(height: 4)
-						TasteGraphView(steps: Int(item.makTasteFresh ?? 0))
+						TasteGraphView(steps: Int(item.freshness))
 							.frame(height: 4)
 					}
 					.padding(.vertical, 12)

--- a/Projects/FeatureInformation/Scene/Components/InfoAwardsView.swift
+++ b/Projects/FeatureInformation/Scene/Components/InfoAwardsView.swift
@@ -11,26 +11,8 @@ import DesignSystem
 import Core
 
 struct InfoAwardsView: View {
-			var awardRawData: [String] = ["2022 우리술 품평회 대상"]
-//		var awardRawData: [String] = ["2019 우리술 품평회 대상", "2022 대한민국 주류대상 대상"]
-//			var awardRawData: [String] = ["2022 우리술 품평회 대상", "2019 대한민국 주류대상 대상", "2018 대한민국 주류대상 대상"]
-//	var awardRawData: [String] = ["2022 우리술 품평회 대상", "2019 대한민국 주류대상 대상", "2015 대한민국 주류대상 대상", "2017 우리술 품평회 대상"]
 	
-	var awards: [Award] {
-		return awardRawData.map { awardString in
-			let components = awardString.components(separatedBy: " ")
-			if components.count >= 4 {
-				let yearString = components[0]
-				let year = Int(yearString) ?? 0
-				let name = components[1] + " " 	+ components[2]
-				let type = components[3]
-				return Award(year: year, name: name, type: type)
-			}
-			return Award(year: 0, name: "", type: "")
-		}
-		.sorted { $0.year > $1.year }
-	}
-	
+	var awards: [Award] = Award.mockDatas
 	var count: Int {
 		return awards.count
 	}

--- a/Projects/FeatureInformation/Scene/Components/InfoLinkView.swift
+++ b/Projects/FeatureInformation/Scene/Components/InfoLinkView.swift
@@ -12,11 +12,9 @@ import Core
 
 struct InfoLinkView: View {
 	
-	public let salesURL: String? /// 판매 사이트
 	public let brewery: Brewery /// 양조장
 	
-	init(salesURL: String?, brewery: Brewery) {
-		self.salesURL = salesURL
+	init(brewery: Brewery) {
 		self.brewery = brewery
 	}
 	
@@ -65,7 +63,7 @@ struct InfoLinkView: View {
 			DividerView()
 			
 			//판매 링크
-			if let url = salesURL {
+			if let url = brewery.salesURL {
 				
 				HStack(alignment: .center) {
 					Text("판매 링크")
@@ -89,6 +87,6 @@ struct InfoLinkView: View {
 
 struct InfoLinkView_Previews: PreviewProvider {
 	static var previews: some View {
-		InfoLinkView(salesURL: "https://smartstore.naver.com/yangjudoga/products/4714123125", brewery: Brewery(name: "별산의 막걸리", url: "https://www.good-tomorrow.co.k"))
+		InfoLinkView(brewery: Brewery.mockTenTen)
 	}
 }

--- a/Projects/FeatureInformation/Scene/Components/LikeControllerView.swift
+++ b/Projects/FeatureInformation/Scene/Components/LikeControllerView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Core
 
 struct LikeControllerView: View {
-	@State var buttonState: LikeState = .none
+	@State var buttonState: Bool? = true
 	
 	var body: some View {
 		HStack(spacing: 16) {
@@ -24,44 +24,44 @@ struct LikeControllerView: View {
 extension LikeControllerView {
 	
 	struct LikeButton: View {
-		@Binding var buttonState: LikeState
+		@Binding var buttonState: Bool?
 		var body: some View {
 			Button(action: {
-				buttonState = .like
+				buttonState = (buttonState == true) ? nil : true
 			}, label: {
 				ZStack{
 					RoundedRectangle(cornerRadius: 12)
 						.frame(height: 50)
-						.foregroundColor(buttonState == .like ? Color(uiColor: .designSystem(.goldenyellow)!) : Color(uiColor: .designSystem(.w10)!))
+						.foregroundColor(buttonState == true ? Color(uiColor: .designSystem(.goldenyellow)!) : Color(uiColor: .designSystem(.w10)!))
 					
 					HStack(spacing: 3) {
 						Image(systemName: "hand.thumbsup.fill")
 						Text("좋았어요")
 					}
 					.font(.style(.SF17R))
-					.foregroundColor(buttonState == .like ? Color(uiColor: .designSystem(.white)!) : Color(uiColor: .designSystem(.lightgrey)!))
+					.foregroundColor(buttonState == true ? Color(uiColor: .designSystem(.white)!) : Color(uiColor: .designSystem(.lightgrey)!))
 				}
 			})
 		}
 	}
 	
 	struct DisLikeButton: View {
-		@Binding var buttonState: LikeState
+		@Binding var buttonState: Bool?
 		var body: some View {
 			Button(action: {
-				buttonState = .dislike
+				buttonState = (buttonState == false) ? nil : false
 			}, label: {
 				ZStack{
 					RoundedRectangle(cornerRadius: 12)
 						.frame(height: 50)
-						.foregroundColor(buttonState == .dislike ? Color(uiColor: .designSystem(.lilac)!) : Color(uiColor: .designSystem(.w10)!))
+						.foregroundColor(buttonState == false ? Color(uiColor: .designSystem(.lilac)!) : Color(uiColor: .designSystem(.w10)!))
 					
 					HStack(spacing: 3) {
 						Image(systemName: "hand.thumbsdown.fill")
 						Text("아쉬워요")
 					}
 					.font(.style(.SF17R))
-					.foregroundColor(buttonState == .dislike ? Color(uiColor: .designSystem(.white)!) : Color(uiColor: .designSystem(.lightgrey)!))
+					.foregroundColor(buttonState == false ? Color(uiColor: .designSystem(.white)!) : Color(uiColor: .designSystem(.lightgrey)!))
 				}
 			})
 		}

--- a/Projects/FeatureInformation/Scene/InformationView.swift
+++ b/Projects/FeatureInformation/Scene/InformationView.swift
@@ -19,7 +19,7 @@ public struct InformationView: View {
 		ScrollView {
 			VStack(spacing: 10) {
 				
-				TasteScoreView(type: .large, taste: Taste(sweetness: .none, sourness: .two, thickness: .five, freshness: .one))
+				TasteScoreView(type: .large, sweetness: -1, sourness: 1, thickness: 2, freshness: 5)
 				
 				LikeControllerView()
 					.padding(.horizontal, 16)
@@ -30,7 +30,7 @@ public struct InformationView: View {
 				InfoIngredientsView()
 					.padding(.horizontal, 16)
 				
-				InfoLinkView(salesURL: "https://smartstore.naver.com/yangjudoga/products/4714123125", brewery: Brewery(name: "별산의 막걸리", url: "https://www.good-tomorrow.co.kr"))
+				InfoLinkView(brewery: Brewery.mockADA)
 					.padding(.horizontal, 16)
 				
 			}

--- a/Projects/FeatureSearch/Scene/SearchResultView/SearchResultSingleView.swift
+++ b/Projects/FeatureSearch/Scene/SearchResultView/SearchResultSingleView.swift
@@ -25,7 +25,7 @@ struct SearchResultSingleView: View {
 			
 			Spacer()
 			
-			TasteScoreView(type: .mini, taste: makHoly.taste)
+			TasteScoreView(type: .mini, sweetness: makHoly.sweetness, sourness: makHoly.sourness, thickness: makHoly.thickness, freshness: makHoly.freshness)
 			
 		}
 		.frame(height: 80)
@@ -58,7 +58,7 @@ extension SearchResultSingleView {
 			Text(makHoly.name)
 				.font(.style(.SF14R))
 				.foregroundColor(Color(uiColor: .designSystem(.white)!))
-			Text(makHoly.formattedSet())
+			Text(String.formattedSet(adv: makHoly.adv, volume: makHoly.volume, price: makHoly.price))
 				.font(.style(.SF12R))
 				.foregroundColor(Color(uiColor: .designSystem(.white)!))
 				.opacity(0.5)

--- a/Projects/FeatureSearch/Scene/SearchViewModel.swift
+++ b/Projects/FeatureSearch/Scene/SearchViewModel.swift
@@ -74,10 +74,10 @@ final class SearchViewModel: ObservableObject {
 	func searchMakHolies(searchText: String) {
 		resultMakHolies = []
 		
-		for makHoly in MakHoly.mockMakHolies {
+		for makHoly in MakHoly.mockDatas {
 			if makHoly.name.contains(searchText) ||
 				makHoly.brewery.name.contains(searchText) ||
-				makHoly.ingredients.contains(where: { $0.contains(searchText) }) ||
+				makHoly.ingredients.contains(searchText) ||
 				makHoly.awards.contains(where: { $0.name.contains(searchText) })
 			{
 				self.resultMakHolies.append(makHoly)


### PR DESCRIPTION
## Motivation
Mok 데이터 추가
MakHoly 데이터 타입 구현


## Changes
- Core / Models / MakHoly 폴더에 있는 데이터 타입
- MakHolyTestData 파일 - 각 타입별로 MokData
- 각 View 별로 MakHoly 변경으로 오류나는 것들 수정했습니다. 


## To Reviewers
- MokData 사용방법
각 타입별로 타입프로퍼티로 MokData 찾으시면 됩니다! 
지금 만들어둔 Comment, User,  MakHolyMini, MakHoly 데이터들은 Id값으로 연결이 실제로 유효해요.

```
MakHolyMini.test1 // MakHolyMini 타입 Mock 데이터
MakHolyMini.mokDatas // MakHolyMini 배열 타입(14개)  Mock 데이터
MakHoly.mockDatas // MakHoly 배열 타입(2개)  Mock 데이터
User.user1 // User 타입 Mock 데이터
```
