### PR TITLE
#44 / MakHolyImageView 구현

### DIFF
--- a/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
+++ b/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
@@ -1,0 +1,46 @@
+//
+//  MakHolyImageView.swift
+//  Core
+//
+//  Created by Eric Lee on 11/4/23.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import SwiftUI
+import Kingfisher
+
+public struct MakHolyImageView: View {
+	
+	let imageId: String
+	let type: ImageType
+	let ratio: ImageRatioType
+	var imageURL: URL? {
+		let baseURL = "https://d2hyndjmu9mjcd.cloudfront.net/images/"
+		let urlString = "\(baseURL)\(imageId).png?\(self.type.query)&\(self.ratio.query)"
+		return URL(string: urlString)
+	}
+	
+	public init(
+		imageId: String,
+		type: ImageType,
+		ratio: ImageRatioType = .outside) {
+			self.imageId = imageId
+			self.type = type
+			self.ratio = ratio
+		}
+	
+	public var body: some View {
+		KFImage(self.imageURL)
+			.placeholder {
+				ProgressView()
+			}
+			.loadDiskFileSynchronously()
+			.cacheMemoryOnly()
+			.fade(duration: 0.15)
+			.retry(maxCount: 3, interval: .seconds(5))
+			.resizable()
+			.scaledToFit()
+			.frame(width: self.type.size.width, height: self.type.size.height)
+	}
+	
+}

--- a/Projects/Core/Sources/Models/Category/CategoryType.swift
+++ b/Projects/Core/Sources/Models/Category/CategoryType.swift
@@ -9,9 +9,12 @@
 import Foundation
 
 public enum CategoryType {
-	case characteristics /// 특징으로 찾기
-	case event /// 주룩 개발자 픽
-	case new /// 새로 나왔어요
+	/// 특징으로 찾기
+	case characteristics
+	/// 주룩 개발자 픽
+	case event
+	/// 새로 나왔어요
+	case new
 	
 	public var description: String {
 		switch self {

--- a/Projects/Core/Sources/Models/Image/ImageRatioType.swift
+++ b/Projects/Core/Sources/Models/Image/ImageRatioType.swift
@@ -1,0 +1,32 @@
+//
+//  ImageRatioType.swift
+//  Core
+//
+//  Created by Eric Lee on 11/4/23.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import Foundation
+
+public enum ImageRatioType {
+	case cover
+	case contain
+	case inside
+	case outside
+	case fill
+	
+	public var query: String {
+		switch self {
+		case .cover:
+			return "t=cover"
+		case .contain:
+			return "t=contain"
+		case .inside:
+			return "t=inside"
+		case .outside:
+			return "t=outside"
+		case .fill:
+			return "t=fill"
+		}
+	}
+}

--- a/Projects/Core/Sources/Models/Image/ImageType.swift
+++ b/Projects/Core/Sources/Models/Image/ImageType.swift
@@ -1,0 +1,33 @@
+//
+//  ImageType.swift
+//  Core
+//
+//  Created by Eric Lee on 11/4/23.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import Foundation
+
+public enum ImageType {
+	case mini
+	case small
+	case middle
+	case large
+	
+	public var size: CGSize {
+		switch self {
+		case .mini:
+			return CGSize(width: 29, height: 60)
+		case .small:
+			return CGSize(width: 66, height: 136)
+		case .middle:
+			return CGSize(width: 56, height: 114)
+		case .large:
+			return CGSize(width: 77, height: 156)
+		}
+	}
+	
+	public var query: String {
+		return "w=\(Int(size.width))&h=\(Int(size.height))"
+	}
+}

--- a/Projects/Core/Sources/Models/MakHoly/Brewery.swift
+++ b/Projects/Core/Sources/Models/MakHoly/Brewery.swift
@@ -9,9 +9,12 @@
 import Foundation
 
 public struct Brewery: Hashable {
-	public let name: String /// 양조장 이름
-	public let url: String? /// 양조장 사이트
-	public let salesURL: String? /// 판매 사이트
+	/// 양조장 이름
+	public let name: String
+	/// 양조장 사이트
+	public let url: String?
+	/// 판매 사이트
+	public let salesURL: String?
 	
 	public init(name: String, url: String?, salesURL: String?) {
 		self.name = name

--- a/Projects/Core/Sources/Models/MakHoly/Comment.swift
+++ b/Projects/Core/Sources/Models/MakHoly/Comment.swift
@@ -9,12 +9,18 @@
 import Foundation
 
 public struct Comment: Identifiable, Hashable {
-	public let id: String // 코멘트 ID
-	public let makHolyId: String // 막걸리 ID
-	public let userId: String // user ID
-	public let isOpened: Bool // 공개여부
-	public let description: String // 코멘트 내용
-	public let date: String // 날짜
+	/// 코멘트 ID
+	public let id: String
+	/// 막걸리 ID
+	public let makHolyId: String
+	/// user ID
+	public let userId: String
+	/// 공개 여부
+	public let isOpened: Bool
+	/// 코멘트 내용
+	public let description: String
+	///  코멘트 작성 날짜
+	public let date: String
 	
 	public init(id: String,
 				makHolyId: String,

--- a/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
@@ -51,26 +51,43 @@ public struct MakHoly: Identifiable, Hashable {
 		self.dislikeUsers = dislikeUsers
 		self.bookmarkUsers = bookmarkUsers
 	}
+	/// 막걸리 ID
+	public let id: String
+	/// 막걸리 이름
+	public let name: String
+	/// 이미지 Id
+	public let imageId: String
+	/// 단맛 점수
+	public let sweetness: Int
+	/// 신맛 점수
+	public let sourness: Int
+	/// 걸쭉 점수
+	public let thickness: Int
+	/// 청량 점수
+	public let freshness: Int
+	/// 가격
+	public let price: Int
+	/// 용량
+	public let volume: Int
+	/// 도수
+	public let adv: Double
+	/// 원재료
+	public let ingredients: String
+	/// 막걸리 설명
+	public let description: String
 	
-	public let id: String // 막걸리 ID - Seq
-	public let name: String // 막걸리 이름
-	public let imageId: String // 이미지 ID
-	public let sweetness: Int // 단맛 점수
-	public let sourness: Int // 신맛 점수
-	public let thickness: Int // 걸쭉 점수
-	public let freshness: Int // 청량 점수
-	public let price: Int // 가격
-	public let volume: Int // 용량
-	public let adv: Double // 알코올 도수
-	public let ingredients: String // 원재료
-	public let description: String // 막걸리 설명
+	/// 양조장
+	public let brewery: Brewery
 	
-	public let brewery: Brewery // 브루어리
+	/// 코멘트 배열
+	public let comments: [Comment]
+	/// 수상 배열
+	public let awards: [Award]
 	
-	public let comments: [Comment] // 코멘트 리스트 모음
-	public let awards: [Award] // 수상 리스트
-	
-	public let likeUsers: [String] // 유저 ID
-	public let dislikeUsers: [String] // 유저 ID
-	public let bookmarkUsers: [String] // 유저 ID
+	/// 좋아요 유저 ID 배열
+	public let likeUsers: [String]
+	/// 싫어요 유저 ID 배열
+	public let dislikeUsers: [String]
+	/// 북마크 유저 ID 배열
+	public let bookmarkUsers: [String]
 }

--- a/Projects/Core/Sources/Models/MakHoly/MakHolyMini.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHolyMini.swift
@@ -9,16 +9,26 @@
 import Foundation
 
 public struct MakHolyMini: Identifiable, Hashable {
-	public let id: String // 막걸리 ID - Seq
-	public let name: String // 막걸리 이름
-	public let imageId: String // 이미지 ID
-	public let sweetness: Int // 단맛 점수
-	public let sourness: Int // 신맛 점수
-	public let thickness: Int // 걸쭉 점수
-	public let freshness: Int // 청량 점수
-	public let price: Int // 가격
-	public let volume: Int // 용량
-	public let adv: Double // 알코올 도수
+	/// 막걸리 ID
+	public let id: String
+	///막걸리 이름
+	public let name: String
+	/// 이미지 ID
+	public let imageId: String
+	/// 단맛 점수
+	public let sweetness: Int
+	/// 신맛 점수
+	public let sourness: Int
+	/// 걸쭉 점수
+	public let thickness: Int
+	/// 청량 점수
+	public let freshness: Int
+	/// 가격
+	public let price: Int
+	/// 용량
+	public let volume: Int
+	/// 도수
+	public let adv: Double
 	
 	public init(id: String,
 				name: String,

--- a/Projects/Core/Sources/Models/MakHoly/MakHolyTestData.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHolyTestData.swift
@@ -305,7 +305,10 @@ extension MakHolyMini {
 }
 
 extension MakHoly {
-	public static var mockDatas: [MakHoly] = [test1, test2]
+	public static var mockDatas: [MakHoly] = [
+		test1, test2, test3, test4, test5, test6, test7,
+		test8, test9, test10, test11, test12, test13, test14
+	]
 	
 	public static var test1: MakHoly = MakHoly(
 		makHolyMini: MakHolyMini.test1,
@@ -336,4 +339,175 @@ extension MakHoly {
 			url: "http://drink.ksdb.co.kr/",
 			salesURL: nil)
 	)
+	
+	public static var test3: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test3,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	
+	public static var test4: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test4,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test5: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test5,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test6: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test6,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test7: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test7,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test8: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test8,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test9: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test9,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test10: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test10,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test11: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test11,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test12: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test12,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test13: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test13,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	public static var test14: MakHoly = MakHoly(
+		makHolyMini: MakHolyMini.test14,
+		comments: [],
+		awards: [],
+		likeUsers: [],
+		dislikeUsers: [],
+		bookmarkUsers: [],
+		ingredients: "",
+		description: "",
+		brewery: Brewery(
+			name: "임시",
+			url: nil,
+			salesURL: nil)
+	)
+	
 }

--- a/Projects/Core/Sources/Models/User/User.swift
+++ b/Projects/Core/Sources/Models/User/User.swift
@@ -9,12 +9,18 @@
 import Foundation
 
 public struct User {
+	/// 유저  Id
 	public let id: String // UUID
+	/// 유저 닉네임
 	public let name: String // 유저네임
-	public let bookmarks: [String] // 찜 목록 - 막걸리 ID 리스트
-	public let likes: [String] // 좋았어요 목록 - 막걸리 ID 리스트
-	public let dislikes: [String] // 아쉬워요 목록 - 막걸리 ID 리스트
-	public let comments: [String] // 코멘트 단 목록 - 코멘트 ID 리스트
+	/// 찜 막걸리 ID 리스트
+	public let bookmarks: [String]
+	/// 좋았어요 막걸리 ID 리스트
+	public let likes: [String] 	
+	/// 아쉬워요 막걸리 ID 리스트
+	public let dislikes: [String]
+	/// 코멘트 막걸리 ID 리스트
+	public let comments: [String]
 	
 	public init(id: String,
 				name: String,

--- a/Projects/DesignSystem/Sources/Colors/Color.swift
+++ b/Projects/DesignSystem/Sources/Colors/Color.swift
@@ -27,7 +27,7 @@ public enum TENTENColor {
 	
 	case lilac
 	
-	/// 컬러를 불러오기 위한 name space
+	/// Color name space
 	public var name: String {
 		switch self {
 		case .darkbase: return "darkbase"


### PR DESCRIPTION
## Motivation
- issue number : 
#44 

## Changes
- MakHolyImageView - 막걸리 이미지 Id와 type을 통해 생성하는 막걸리 이미지 View

## Screen Shots
|기능|스크린샷|
|:--:|:--:|
|타입별로 비교 | ![Type별로](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-1010/assets/77574120/af83d249-c595-4596-8a7d-11f4b10cb53a)
|Ratio 별로 비교 - cover ,  contain(검정이 여백이 아니라 추가된 색상) ,  inside ,  outside ,  fill |![Ratio별로](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-1010/assets/77574120/bd54a13a-ec6e-4d52-94e2-ca26d76d174e)|


## To Reviewers
- 사용방법
```
import Core

MakHolyImageView(imageId:  ,  type:  )
 MakHolyImageView(imageId:  makHoly.imageId,  type:  .small, ratio: .inside)

```
-  Ratio 은 Outside를 기본 타입으로 해둬서 설정안하고 이니셜가능
- 원본 이미지 자체의 비율이 모두 달라서 일단 안짤리게만 해뒀어요
- 세로보다 가로가 긴 납작한 사진들중에서, 세로가 긴 경우(본 막걸리) / 가로가 넓은 경우(이화백주) 가 있어서 코드로는 해결이 힘들것 같아요
