### PR TITLE
#58/Onboarding UI

### DIFF
--- a/Projects/Core/Sources/Common/Componets/UnderlineView.swift
+++ b/Projects/Core/Sources/Common/Componets/UnderlineView.swift
@@ -1,0 +1,40 @@
+//
+//  UnderlineView.swift
+//  Core
+//
+//  Created by Kim SungHun on 2023/11/09.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import SwiftUI
+
+public struct UnderlineView: ViewModifier {
+	public let spacing: CGFloat
+	public let height: CGFloat
+	public let color: Color
+	
+	init(spacing: CGFloat, height: CGFloat, color: Color) {
+		self.spacing = spacing
+		self.height = height
+		self.color = color
+	}
+	
+	public func body(content: Content) -> some View {
+		VStack(spacing: spacing) {
+			content
+			Rectangle()
+				.frame(height: height)
+				.foregroundColor(color)
+		}
+	}
+}
+
+extension View {
+	public func underlined(spacing: CGFloat = 3,
+						   height: CGFloat = 2,
+						   color: Color = .accentColor) -> some View {
+		self.modifier(UnderlineView(spacing: spacing,
+									height: height,
+									color: color))
+	}
+}

--- a/Projects/Core/Sources/Common/Extensions/View+.swift
+++ b/Projects/Core/Sources/Common/Extensions/View+.swift
@@ -1,0 +1,16 @@
+//
+//  View+.swift
+//  Core
+//
+//  Created by Kim SungHun on 2023/11/09.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+	public func hideKeyboard() {
+		UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+										to: nil, from: nil, for: nil)
+	}
+}

--- a/Projects/Core/Sources/Models/User/SexType.swift
+++ b/Projects/Core/Sources/Models/User/SexType.swift
@@ -1,0 +1,26 @@
+//
+//  SexType.swift
+//  Core
+//
+//  Created by Kim SungHun on 2023/11/09.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import Foundation
+
+public enum SexType: String {
+	case none, male, female, etc
+	
+	public var description: String {
+		switch self {
+		case .none:
+			return ""
+		case .male:
+			return "남성"
+		case .female:
+			return "여성"
+		case .etc:
+			return "기타"
+		}
+	}
+}

--- a/Projects/Core/Sources/Network/Response/User/UserResponse.swift
+++ b/Projects/Core/Sources/Network/Response/User/UserResponse.swift
@@ -12,6 +12,12 @@ public struct UserResponse: Codable {
 	public let status: Int
 	public let resultMsg: String
 	public let result: UserResult?
+	
+	public init(status: Int = 0, resultMsg: String = "", result: UserResult? = nil) {
+		self.status = status
+		self.resultMsg = resultMsg
+		self.result = result
+	}
 }
 
 public struct UserResult: Codable {

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/Contents.json
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileAspartameFree.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileAspartameFree.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "profileAspartameFree.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileAspartameFree.imageset/profileAspartameFree.svg
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileAspartameFree.imageset/profileAspartameFree.svg
@@ -1,0 +1,16 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1173_130692" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="70">
+<rect width="70" height="70" rx="35" fill="#FFC431"/>
+</mask>
+<g mask="url(#mask0_1173_130692)">
+<rect width="70" height="70" fill="url(#paint0_linear_1173_130692)"/>
+<rect x="10.7334" y="-19.6001" width="19.1333" height="74.6667" fill="white"/>
+<rect x="40.1338" y="14.4666" width="19.1333" height="74.6667" fill="white"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1173_130692" x1="35" y1="0" x2="35" y2="70" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileCarbonicAcid.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileCarbonicAcid.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "profileCarbonicAcid.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileCarbonicAcid.imageset/profileCarbonicAcid.svg
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileCarbonicAcid.imageset/profileCarbonicAcid.svg
@@ -1,0 +1,19 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1173_130706" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="70">
+<rect width="70" height="70" rx="35" fill="#FFC431"/>
+</mask>
+<g mask="url(#mask0_1173_130706)">
+<rect width="70" height="70" fill="url(#paint0_linear_1173_130706)"/>
+<rect x="18.9834" y="-16.2163" width="21.1895" height="21.1895" transform="rotate(45 18.9834 -16.2163)" fill="white"/>
+<rect x="18.9834" y="20.0168" width="21.1895" height="21.1895" transform="rotate(45 18.9834 20.0168)" fill="white"/>
+<rect x="18.9834" y="56.25" width="21.1895" height="21.1895" transform="rotate(45 18.9834 56.25)" fill="white"/>
+<rect x="51.0166" y="38.1333" width="21.1895" height="21.1895" transform="rotate(45 51.0166 38.1333)" fill="white"/>
+<rect x="51.0166" y="1.90039" width="21.1895" height="21.1895" transform="rotate(45 51.0166 1.90039)" fill="white"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1173_130706" x1="35" y1="0" x2="35" y2="70" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileHighlyHydrated.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileHighlyHydrated.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "profileHighlyHydrated.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileHighlyHydrated.imageset/profileHighlyHydrated.svg
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileHighlyHydrated.imageset/profileHighlyHydrated.svg
@@ -1,0 +1,20 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1173_130687" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="70">
+<rect width="70" height="70" rx="35" fill="#FFC431"/>
+</mask>
+<g mask="url(#mask0_1173_130687)">
+<rect width="70" height="70" fill="url(#paint0_linear_1173_130687)"/>
+<rect x="13.0664" y="13.0667" width="44.3333" height="44.3333" fill="white"/>
+<rect x="25.667" y="25.6667" width="18.6667" height="18.6667" fill="url(#paint1_linear_1173_130687)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1173_130687" x1="35" y1="0" x2="35" y2="70" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1173_130687" x1="35.0003" y1="25.6667" x2="35.0003" y2="44.3334" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSour.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSour.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "profileSour.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSour.imageset/profileSour.svg
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSour.imageset/profileSour.svg
@@ -1,0 +1,15 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1173_130702" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="70">
+<rect width="70" height="70" rx="35" fill="#FFC431"/>
+</mask>
+<g mask="url(#mask0_1173_130702)">
+<rect width="70" height="70" fill="url(#paint0_linear_1173_130702)"/>
+<path d="M35.0012 0L41.6974 18.8329L59.7493 10.2507L51.1695 28.3026L70 35.0012L51.1695 41.6974L59.7493 59.7493L41.6974 51.1695L35.0012 70L28.3026 51.1695L10.2507 59.7493L18.8329 41.6974L0 35.0012L18.8329 28.3026L10.2507 10.2507L28.3026 18.8329L35.0012 0Z" fill="white"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1173_130702" x1="35" y1="0" x2="35" y2="70" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSweet.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSweet.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "profileSweet.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSweet.imageset/profileSweet.svg
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileSweet.imageset/profileSweet.svg
@@ -1,0 +1,16 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1173_130679" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="70">
+<rect width="70" height="70" rx="35" fill="#FFC431"/>
+</mask>
+<g mask="url(#mask0_1173_130679)">
+<rect width="70" height="70" fill="url(#paint0_linear_1173_130679)"/>
+<rect x="22.5215" y="27.1187" width="39.0116" height="82.0572" rx="19.5058" transform="rotate(-45 22.5215 27.1187)" fill="white"/>
+<rect x="-38.2666" y="12.1853" width="39.0116" height="82.0572" rx="19.5058" transform="rotate(-45 -38.2666 12.1853)" fill="white"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1173_130679" x1="35" y1="0" x2="35" y2="70" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileThick.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileThick.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "profileThick.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileThick.imageset/profileThick.svg
+++ b/Projects/DesignSystem/Resources/Images.xcassets/Profile/profileThick.imageset/profileThick.svg
@@ -1,0 +1,20 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1173_130697" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="70">
+<rect width="70" height="70" rx="35" fill="#FFC431"/>
+</mask>
+<g mask="url(#mask0_1173_130697)">
+<rect width="70" height="70" fill="white"/>
+<circle cx="-11.1667" cy="34.8333" r="40.8333" fill="url(#paint0_linear_1173_130697)"/>
+<circle cx="81.0325" cy="34.8333" r="40.8333" fill="url(#paint1_linear_1173_130697)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1173_130697" x1="-11.1667" y1="-6" x2="-11.1667" y2="75.6667" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1173_130697" x1="81.0325" y1="-6" x2="81.0325" y2="75.6667" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADADFF"/>
+<stop offset="0.442708" stop-color="#7676D3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/Projects/DesignSystem/Sources/Fonts/Font+.swift
+++ b/Projects/DesignSystem/Sources/Fonts/Font+.swift
@@ -35,6 +35,8 @@ extension Font {
 			return .system(size: 16, weight: .regular)
 		case .SF15R:
 			return .system(size: 15, weight: .regular)
+		case .SF20B:
+			return .system(size: 20, weight: .bold)
 		}
 		
 	}

--- a/Projects/DesignSystem/Sources/Fonts/Font.swift
+++ b/Projects/DesignSystem/Sources/Fonts/Font.swift
@@ -21,5 +21,6 @@ public enum TENTENFont {
 	case SF10R
 	case SF16R
 	case SF15R
+	case SF20B
 	
 }

--- a/Projects/DesignSystem/Sources/Images/Asset.swift
+++ b/Projects/DesignSystem/Sources/Images/Asset.swift
@@ -52,6 +52,13 @@ public enum TENTENAsset {
 		case heart
 		case person
 		
+		case profileSweet
+		case profileSour
+		case profileAspartameFree
+		case profileCarbonicAcid
+		case profileHighlyHydrated
+		case profileThick
+		
 		public var description: String {
 			switch self {
 			case .mockMakgeolli:
@@ -125,6 +132,19 @@ public enum TENTENAsset {
 				return "heart"
 			case .person:
 				return "person"
+				
+			case .profileSweet:
+				return "profileSweet"
+			case .profileSour:
+				return "profileSour"
+			case .profileAspartameFree:
+				return "profileAspartameFree"
+			case .profileCarbonicAcid:
+				return "profileCarbonicAcid"
+			case .profileHighlyHydrated:
+				return "profileHighlyHydrated"
+			case .profileThick:
+				return "profileThick"
 			}
 		}
 	}

--- a/Projects/Feature/Scene/RootView.swift
+++ b/Projects/Feature/Scene/RootView.swift
@@ -8,42 +8,50 @@
 import SwiftUI
 import Core
 import DesignSystem
+import Utils
 import FeatureEncyclopedia
 import FeatureHome
 import FeatureProfile
 import FeatureSearch
+import FeatureOnboarding
 
 public struct RootView: View {
 	public init() {
 		setCustomNavigationBar()
 	}
 	
+	private let randomNickname = ["걸쭉한라쿤", "상큼한라쿤", "달달한라쿤"]
+	
 	public var body: some View {
-		TabView {
-			HomeView()
-				.tabItem {
-					Image(uiImage: .designSystem(.home)!)
-					Text("홈")
-						.font(.style(.SF10B))
-				}
-			SearchView()
-				.tabItem {
-					Image(uiImage: .designSystem(.search)!)
-					Text("검색")
-						.font(.style(.SF10B))
-				}
-			EncyclopediaView()
-				.tabItem {
-					Image(uiImage: .designSystem(.heart)!)
-					Text("내 막걸리")
-						.font(.style(.SF10B))
-				}
-			ProfileView()
-				.tabItem {
-					Image(uiImage: .designSystem(.person)!)
-					Text("내 정보")
-						.font(.style(.SF10B))
-				}
+		if KeyChainManager.shared.read(account: .userId).isEmpty {
+			OnboardingView(nickname: randomNickname.randomElement()!)
+		} else {
+			TabView {
+				HomeView()
+					.tabItem {
+						Image(uiImage: .designSystem(.home)!)
+						Text("홈")
+							.font(.style(.SF10B))
+					}
+				SearchView()
+					.tabItem {
+						Image(uiImage: .designSystem(.search)!)
+						Text("검색")
+							.font(.style(.SF10B))
+					}
+				EncyclopediaView()
+					.tabItem {
+						Image(uiImage: .designSystem(.heart)!)
+						Text("내 막걸리")
+							.font(.style(.SF10B))
+					}
+				ProfileView()
+					.tabItem {
+						Image(uiImage: .designSystem(.person)!)
+						Text("내 정보")
+							.font(.style(.SF10B))
+					}
+			}
 		}
 	}
 }

--- a/Projects/FeatureAuth/Scene/AuthView.swift
+++ b/Projects/FeatureAuth/Scene/AuthView.swift
@@ -17,8 +17,8 @@ public struct AuthView: View {
 	public var body: some View {
 		Button {
 			Task {
-				try KeyChainManager.shared.create(account: .accessToken,
-												  data: UUID().uuidString)
+				try KeyChainManager.shared.create(account: .userId,
+												  data: 0)
 				keychainCreated = true
 			}
 		} label: {

--- a/Projects/FeatureOnboarding/Scene/CustomizationInfo/CustomizationInfoView.swift
+++ b/Projects/FeatureOnboarding/Scene/CustomizationInfo/CustomizationInfoView.swift
@@ -42,7 +42,7 @@ struct CustomizationInfoView: View {
 				Spacer()
 					.frame(height: 40)
 				
-				TextField("2023 (출생년도)", text: $yearOfBirth)
+				TextField("2004 (출생년도)", text: $yearOfBirth)
 					.font(.style(.SF20B))
 					.keyboardType(.numberPad)
 					.onReceive(Just(yearOfBirth)) { newValue in

--- a/Projects/FeatureOnboarding/Scene/CustomizationInfo/CustomizationInfoView.swift
+++ b/Projects/FeatureOnboarding/Scene/CustomizationInfo/CustomizationInfoView.swift
@@ -1,0 +1,184 @@
+//
+//  CustomizationInfoView.swift
+//  FeatureOnboarding
+//
+//  Created by Kim SungHun on 2023/11/08.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import SwiftUI
+import Core
+import Combine
+import DesignSystem
+import FeatureHome
+import FeatureSearch
+import FeatureEncyclopedia
+import FeatureProfile
+
+struct CustomizationInfoView: View {
+	@ObservedObject var viewModel: OnboardingViewModel
+	
+	@State var isNavigationRoot = false
+	@State var sexType: SexType = .none
+	@State var yearOfBirth: String = ""
+	
+	@Binding var nickname: String
+	
+	var body: some View {
+		ZStack {
+			if viewModel.fetchLoading {
+				ProgressView()
+					.frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+					.foregroundColor(Color(uiColor: .designSystem(.white)!))
+			}
+			VStack(spacing: 0) {
+				MakeProfileView()
+				
+				Spacer()
+					.frame(height: 36)
+				
+				SetSexTypeView()
+				
+				Spacer()
+					.frame(height: 40)
+				
+				TextField("2023 (출생년도)", text: $yearOfBirth)
+					.font(.style(.SF20B))
+					.keyboardType(.numberPad)
+					.onReceive(Just(yearOfBirth)) { newValue in
+						let filtered = newValue.filter { "0123456789".contains($0) }
+						if filtered != newValue {
+							self.yearOfBirth = filtered
+						}
+						if self.yearOfBirth.count == 5 {
+							self.yearOfBirth.removeLast()
+						}
+					}
+					.underlined()
+				
+				Spacer()
+				
+				Button {
+					viewModel.skipSignin(nickname: nickname, sex: sexType.description,
+										 ageRange: yearOfBirth)
+					
+				} label: {
+					RoundedRectangle(cornerRadius: 12)
+						.fill(Color(uiColor: .designSystem(
+							!yearOfBirth.isEmpty && sexType != .none ? .goldenyellow : .w10)!)
+						)
+						.frame(height: 50)
+						.overlay {
+							Text("입력완료")
+								.foregroundColor(.white)
+								.SF17R()
+						}
+				}
+				.padding(.bottom, 16)
+				.disabled(!yearOfBirth.isEmpty && sexType != .none ? false : true)
+				
+			}
+			.navigationDestination(isPresented: $viewModel.navigationState) {
+				TabView {
+					HomeView()
+						.tabItem {
+							Image(uiImage: .designSystem(.home)!)
+							Text("홈")
+								.font(.style(.SF10B))
+						}
+					SearchView()
+						.tabItem {
+							Image(uiImage: .designSystem(.search)!)
+							Text("검색")
+								.font(.style(.SF10B))
+						}
+					EncyclopediaView()
+						.tabItem {
+							Image(uiImage: .designSystem(.heart)!)
+							Text("내 막걸리")
+								.font(.style(.SF10B))
+						}
+					ProfileView()
+						.tabItem {
+							Image(uiImage: .designSystem(.person)!)
+							Text("내 정보")
+								.font(.style(.SF10B))
+						}
+				}
+				.navigationBarBackButtonHidden()
+			}
+			.padding(.horizontal, 16)
+		}
+	}
+}
+
+private extension CustomizationInfoView {
+	@ViewBuilder
+	func MakeProfileView() -> some View {
+		Spacer()
+			.frame(height: 20)
+		
+		HStack(spacing: 0) {
+			Text(nickname)
+				.SF24B()
+				.foregroundColor(.Primary2)
+			Text("님의")
+				.SF24B()
+		}
+		.padding(.bottom, 4)
+		
+		Text("맞춤 정보를 알려주세요")
+			.SF24B()
+		
+		Spacer()
+			.frame(height: 10)
+		
+		Text("더 나은 막걸리를 추천해드릴게요")
+			.SF14R()
+	}
+	
+	@ViewBuilder
+	func SetSexTypeView() -> some View {
+		HStack(spacing: 16) {
+			Button {
+				sexType = .male
+			} label: {
+				RoundedRectangle(cornerRadius: 12)
+					.fill(Color(uiColor: .designSystem(sexType == .male
+													   ? .goldenyellow : .w10)!))
+					.frame(height: 50)
+					.overlay {
+						Text("남성")
+							.foregroundColor(.white)
+							.SF17R()
+					}
+			}
+			Button {
+				sexType = .female
+			} label: {
+				RoundedRectangle(cornerRadius: 12)
+					.fill(Color(uiColor: .designSystem(sexType == .female
+													   ? .goldenyellow : .w10)!))
+					.frame(height: 50)
+					.overlay {
+						Text("여성")
+							.foregroundColor(.white)
+							.SF17R()
+					}
+			}
+			Button {
+				sexType = .etc
+			} label: {
+				RoundedRectangle(cornerRadius: 12)
+					.fill(Color(uiColor: .designSystem(sexType == .etc
+													   ? .goldenyellow : .w10)!))
+					.frame(height: 50)
+					.overlay {
+						Text("기타")
+							.foregroundColor(.white)
+							.SF17R()
+					}
+			}
+		}
+	}
+}

--- a/Projects/FeatureOnboarding/Scene/OnboardingView.swift
+++ b/Projects/FeatureOnboarding/Scene/OnboardingView.swift
@@ -7,16 +7,147 @@
 //
 
 import SwiftUI
+import Core
+import DesignSystem
+import Utils
 
 public struct OnboardingView: View {
-	public init () { }
+	@StateObject var viewModel = OnboardingViewModel(userRepository: DefaultUserRepository())
+	
+	@State var nickname: String
+	@State var selectedImage: ImageName = .profileSweet
+	
+	enum ImageName: String {
+		case profileSweet, profileHighlyHydrated, profileThick,
+			 profileCarbonicAcid, profileAspartameFree, profileSour
+	}
+	
+	public init (nickname: String) {
+		self.nickname = nickname
+	}
+	
 	public var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
+		NavigationStack {
+			ZStack {
+				VStack(spacing: 0) {
+					MakeProfileView(name: $nickname)
+					
+					Spacer()
+						.frame(height: 40)
+					
+					TextField("닉네임을 입력해주세요", text: $nickname)
+						.font(.style(.SF20B))
+						.underlined()
+					
+					Spacer()
+						.frame(height: 80)
+					
+					SetUserIconView()
+					
+					Spacer()
+					
+					Text("이용약관과 개인정보처리방침에 동의하고 시작합니다.")
+						.SF12B()
+						.padding(.bottom, 16)
+					
+					NavigationLink {
+						CustomizationInfoView(viewModel: viewModel, nickname: $nickname)
+							.background(Color(uiColor: .designSystem(.darkbase)!))
+							.navigationBarBackButtonHidden(true)
+							.navigationBarItems(leading: CustomBackButton())
+							.toolbarBackground(Color(uiColor: .designSystem(.darkbase)!),
+											   for: .navigationBar)
+							.onAppear {
+								UserDefaultsSetting.profileImage = selectedImage.rawValue
+							}
+					} label: {
+						RoundedRectangle(cornerRadius: 12)
+							.fill(Color(uiColor: .designSystem(.goldenyellow)!))
+							.frame(height: 50)
+							.overlay {
+								Text("다음")
+									.foregroundColor(.white)
+									.SF17R()
+							}
+							.padding(.bottom, 16)
+					}
+				}
+				.padding(.horizontal, 16)
+				.background(Color(uiColor: .designSystem(.darkbase)!))
+				.ignoresSafeArea(.keyboard)
+			}
+			.onTapGesture {
+				self.hideKeyboard()
+			}
+		}
+	}
 }
 
-struct OnboardingView_Previews: PreviewProvider {
-    static var previews: some View {
-        OnboardingView()
-    }
+private extension OnboardingView {
+	@ViewBuilder
+	func MakeProfileView(name: Binding<String>) -> some View {
+		Spacer()
+			.frame(height: 64)
+		
+		HStack(spacing: 0) {
+			Text(name.wrappedValue)
+				.SF24B()
+				.foregroundColor(.Primary2)
+				.padding(.bottom, 4)
+			Text("님,")
+				.SF24B()
+		}
+		Text("프로필을 만들어보세요!")
+			.SF24B()
+	}
+	
+	@ViewBuilder
+	func SetUserIconView() -> some View {
+		HStack(spacing: 20) {
+			Button {
+				selectedImage = .profileSweet
+			} label: {
+				Image(uiImage: .designSystem(.profileSweet)!)
+					.opacity(selectedImage == .profileSweet ? 1 : 0.2)
+			}
+			
+			Button {
+				selectedImage = .profileThick
+			} label: {
+				Image(uiImage: .designSystem(.profileThick)!)
+					.opacity(selectedImage == .profileThick ? 1 : 0.2)
+			}
+			
+			Button {
+				selectedImage = .profileHighlyHydrated
+			} label: {
+				Image(uiImage: .designSystem(.profileHighlyHydrated)!)
+					.opacity(selectedImage == .profileHighlyHydrated ? 1 : 0.2)
+			}
+		}
+		
+		Spacer()
+			.frame(height: 20)
+		
+		HStack(spacing: 20) {
+			Button {
+				selectedImage = .profileCarbonicAcid
+			} label: {
+				Image(uiImage: .designSystem(.profileCarbonicAcid)!)
+					.opacity(selectedImage == .profileCarbonicAcid ? 1 : 0.2)
+			}
+			Button {
+				selectedImage = .profileAspartameFree
+			} label: {
+				Image(uiImage: .designSystem(.profileAspartameFree)!)
+					.opacity(selectedImage == .profileAspartameFree ? 1 : 0.2)
+			}
+			Button {
+				selectedImage = .profileSour
+			} label: {
+				Image(uiImage: .designSystem(.profileSour)!)
+					.opacity(selectedImage == .profileSour ? 1 : 0.2)
+			}
+		}
+	}
 }

--- a/Projects/FeatureOnboarding/Scene/OnboardingViewModel.swift
+++ b/Projects/FeatureOnboarding/Scene/OnboardingViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  OnboardingViewModel.swift
+//  FeatureOnboarding
+//
+//  Created by Kim SungHun on 2023/11/08.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import Foundation
+import Core
+import Utils
+
+final class OnboardingViewModel: ObservableObject {
+	@Published var fetchLoading = false
+	@Published var navigationState = false
+	
+	let userRepository: DefaultUserRepository
+	
+	init(
+		userRepository: DefaultUserRepository
+	) {
+		self.userRepository = userRepository
+	}
+	
+	@MainActor
+	func skipSignin(nickname: String, sex: String, ageRange: String) {
+		fetchLoading = true
+		Task {
+			do {
+				let response = try await userRepository.skipSignin(UserRequest(userNickName: nickname,
+																			   userSex: sex,
+																			   userAgeRange: ageRange))
+				try KeyChainManager.shared.create(account: .userId, data: response.result!.userID!)
+				fetchLoading = false
+				navigationState = true
+			} catch {
+				Logger.debug(error: error, message: "")
+			}
+		}
+	}
+}

--- a/Projects/FeatureOnboarding/Scene/OnboardingViewModel.swift
+++ b/Projects/FeatureOnboarding/Scene/OnboardingViewModel.swift
@@ -30,7 +30,13 @@ final class OnboardingViewModel: ObservableObject {
 				let response = try await userRepository.skipSignin(UserRequest(userNickName: nickname,
 																			   userSex: sex,
 																			   userAgeRange: ageRange))
-				try KeyChainManager.shared.create(account: .userId, data: response.result!.userID!)
+				do {
+					if let response = response.result {
+						try KeyChainManager.shared.create(account: .userId, data: response.userID!)
+					}
+				} catch {
+					Logger.debug(error: error, message: "")
+				}
 				fetchLoading = false
 				navigationState = true
 			} catch {

--- a/Projects/Utils/Sources/KeyChain/KeyChainAccount.swift
+++ b/Projects/Utils/Sources/KeyChain/KeyChainAccount.swift
@@ -9,10 +9,7 @@
 import Foundation
 
 public enum KeyChainAccount {
-	case accessToken
-	case accesstokenExpiredTime
-	case refreshToken
-	case refreshTokenExpiredTime
+	case userId
 	
 	var description: String {
 		return String(describing: self)
@@ -20,13 +17,7 @@ public enum KeyChainAccount {
 	
 	var keyChainClass: CFString {
 		switch self {
-		case .accessToken:
-			return kSecClassGenericPassword
-		case .accesstokenExpiredTime:
-			return kSecClassGenericPassword
-		case .refreshToken:
-			return kSecClassGenericPassword
-		case .refreshTokenExpiredTime:
+		case .userId:
 			return kSecClassGenericPassword
 		}
 	}

--- a/Projects/Utils/Sources/KeyChain/KeyChainManager.swift
+++ b/Projects/Utils/Sources/KeyChain/KeyChainManager.swift
@@ -15,7 +15,7 @@ public final class KeyChainManager {
 	
 	public init() { }
 	
-	public func create(account: KeyChainAccount, data: String) throws {
+	public func create(account: KeyChainAccount, data: Int) throws {
 		let query = [
 			kSecClass: account.keyChainClass,
 			kSecAttrService: KeyChainManager.serviceName,

--- a/Projects/Utils/Sources/UserDefault/UserDefaultsSetting.swift
+++ b/Projects/Utils/Sources/UserDefault/UserDefaultsSetting.swift
@@ -1,0 +1,14 @@
+//
+//  UserDefaultsSetting.swift
+//  Utils
+//
+//  Created by Kim SungHun on 2023/11/09.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import Foundation
+
+public enum UserDefaultsSetting {	
+	@UserDefaultsWrapper(key: "profileImage", defaultValue: "")
+	public static var profileImage
+}

--- a/Projects/Utils/Sources/UserDefault/UserDefaultsWrapper.swift
+++ b/Projects/Utils/Sources/UserDefault/UserDefaultsWrapper.swift
@@ -1,0 +1,38 @@
+//
+//  UserDefaultsWrapper.swift
+//  Utils
+//
+//  Created by Kim SungHun on 2023/11/09.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefaultsWrapper<T: Codable> {
+	private let key: String
+	private let defaultValue: T
+	
+	init(key: String, defaultValue: T) {
+		self.key = key
+		self.defaultValue = defaultValue
+	}
+	
+	var wrappedValue: T {
+		get {
+			if let savedData = UserDefaults.standard.object(forKey: key) as? Data {
+				let decoder = JSONDecoder()
+				if let loadedObject = try? decoder.decode(T.self, from: savedData) {
+					return loadedObject
+				}
+			}
+			return defaultValue
+		}
+		set {
+			let encoder = JSONEncoder()
+			if let encoded = try? encoder.encode(newValue) {
+				UserDefaults.standard.setValue(encoded, forKey: key)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Motivation
- issue number : #58 

## Changes
- Onboarding UI 그리기 및 SkipSignin 로직도 추가했습니다.

## Screen Shots
|기능|스크린샷|
|:--:|:--:|
|UI|![Simulator Screen Recording - iPhone 14 - 2023-11-09 at 02 50 23](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-1010/assets/50910456/192c8387-49cd-49ae-94da-94cf41c1be13)|


## To Reviewers
- Onboarding 쪽에 private extension으로 View를 뺀 부분들은 따로 리팩토링을 하고 싶은데, 우선 지금 PR 올린 시점에서는 정신이 없네요.. Onboarding에서 더 힘을 쏟기가 힘드네요.. 우선 출시하고 리팩하는 방향으로 하려고 합니다.. 메모해놓음!
- 마찬가지로 Onboarding에서 User set 끝나면 tabView로 이동을 해야하는데, 기존에 있던 RootView로는 못가서 똑같은 코드를 써놓긴 했습니다.. 이 부분도 마음에 들지 않기에 추후에 리팩하겠습니다.. 지금 당장 더 좋은 방법이 생각나시면 리뷰 달아주세요! 😄
- KeyChain에 userId는 SkipSignin 하면 받는 userId인데 프론트쪽에서 가지고 있어야 request할때 userId를 실어서 보낼 수 있어서 KeyChain에 저장했습니다.
- UserDefault는 우선 현재 프로필 이미지 string value만 저장했습니다.
- progress, loading 처리를 조금 더 자연스럽게 하고 싶은데, 쉽지가 않네요.. 🥲
