### PR TITLE
#65/막걸리 평가 API 구현 

### DIFF
--- a/Projects/Core/Sources/Network/Request/User/EvaluateMakRequest.swift
+++ b/Projects/Core/Sources/Network/Request/User/EvaluateMakRequest.swift
@@ -13,9 +13,17 @@ public struct EvaluateMakRequest: Codable {
 	let makNumber: Int
 	let likeMak: String
 	
-	public init(userId: Int, makNumber: Int, likeMak: String) {
+	public init(userId: Int, makNumber: Int, likeState: LikeState) {
 		self.userId = userId
 		self.makNumber = makNumber
-		self.likeMak = likeMak
+		switch likeState {
+		case .none:
+			self.likeMak = "D"
+		case .like:
+			self.likeMak = "Y"
+		case .dislike:
+			self.likeMak = "N"
+		}
+		
 	}
 }

--- a/Projects/Core/Sources/Network/Response/User/EvaluateMakResponse.swift
+++ b/Projects/Core/Sources/Network/Response/User/EvaluateMakResponse.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct EvaluateMakResponse: Codable {
 	public let status: Int
-	public let resultMsg: String
+	public let resultMsg: String?
 	public let result: EvaluateMakResult?
 }
 

--- a/Projects/FeatureInformation/Scene/InformationCardView/InfoLikeView.swift
+++ b/Projects/FeatureInformation/Scene/InformationCardView/InfoLikeView.swift
@@ -26,6 +26,7 @@ extension InfoLikeView {
 	func likeButton() -> some View {
 		Button(action: {
 			viewModel.likeButtonTapped()
+			viewModel.postLikeState()
 		}, label: {
 			ZStack{
 				RoundedRectangle(cornerRadius: 12)
@@ -47,6 +48,7 @@ extension InfoLikeView {
 	func dislikeButton() -> some View {
 		Button(action: {
 			viewModel.dislikeButtonTapped()
+			viewModel.postLikeState()
 		}, label: {
 			ZStack{
 				RoundedRectangle(cornerRadius: 12)

--- a/Projects/FeatureInformation/Scene/InformationView.swift
+++ b/Projects/FeatureInformation/Scene/InformationView.swift
@@ -15,7 +15,7 @@ public struct InformationView: View {
 	@StateObject var viewModel: InformationViewModel
 	
 	public init(makHolyId: Int) {
-		self._viewModel = StateObject(wrappedValue: InformationViewModel(makHolyId: makHolyId, maHolyRepo: DefaultMakgeolliRepository()))
+		self._viewModel = StateObject(wrappedValue: InformationViewModel(makHolyId: makHolyId, maHolyRepo: DefaultMakgeolliRepository(), userRepo: DefaultUserRepository()))
 	}
 	
 	public var body: some View {

--- a/Projects/FeatureInformation/Scene/InformationViewModel.swift
+++ b/Projects/FeatureInformation/Scene/InformationViewModel.swift
@@ -61,12 +61,12 @@ final class InformationViewModel: ObservableObject {
 		Task {
 			
 			do {
-				let makHoly = try await maHolyRepo.fetchDetail(makNumber: 5, userId: 1)
+				let makHoly = try await maHolyRepo.fetchDetail(makNumber: self.makHolyId, userId: self.userId)
 				self.makHoly = makHoly
 				print("fetchMakHoly Completed : ------- \n \(makHoly) \n -------")
 				self.isFetchCompleted = true
 			} catch {
-				Logger.debug(error: error, message: "")
+				Logger.debug(error: error, message: "InformationViewModel -fetchMakHoly()")
 			}
 			
 		}
@@ -78,7 +78,7 @@ final class InformationViewModel: ObservableObject {
 		Task {
 			
 			do {
-				let result = try await maHolyRepo.fetchMakLikesAndComments(makNumber: 5)
+				let result = try await maHolyRepo.fetchMakLikesAndComments(makNumber: 1)
 				self.likeDetail = result.0
 				self.comments = result.1
 				print("fetchReactions Completed : -------")
@@ -86,7 +86,7 @@ final class InformationViewModel: ObservableObject {
 				print("comments : \(comments)")
 				print("----------------------------------")
 			} catch {
-				Logger.debug(error: error, message: "")
+				Logger.debug(error: error, message: "InformationViewModel -fetchReactions()")
 			}
 			
 		}

--- a/Projects/FeatureInformation/Scene/InformationViewModel.swift
+++ b/Projects/FeatureInformation/Scene/InformationViewModel.swift
@@ -7,16 +7,22 @@
 //
 
 import SwiftUI
+import Combine
 import Core
 
 final class InformationViewModel: ObservableObject {
 	
 	let makHolyId: Int
+	let userId: Int = 1578568449
 	let maHolyRepo: DefaultMakgeolliRepository
+	let userRepo: DefaultUserRepository
 	
-	init(makHolyId: Int, maHolyRepo: DefaultMakgeolliRepository) {
-		self.makHolyId = makHolyId
+	private var cancellables: Set<AnyCancellable> = []
+	
+	init(makHolyId: Int, maHolyRepo: DefaultMakgeolliRepository, userRepo: DefaultUserRepository) {
+		self.makHolyId = 1
 		self.maHolyRepo = maHolyRepo
+		self.userRepo = userRepo
 	}
 	
 	@Published var isFetchCompleted: Bool = false
@@ -114,6 +120,23 @@ final class InformationViewModel: ObservableObject {
 			self.makHoly.myReaction.likeState = .dislike
 		}
 		
+	}
+	
+	@MainActor
+	func postLikeState() {
+		Task {
+			do {
+				let response = try await userRepo.evaluateMak(EvaluateMakRequest(
+					userId: self.userId,
+					makNumber: self.makHolyId,
+					likeState: self.makHoly.myReaction.likeState))
+				print("postLikeState Completed : -------")
+				print("response : \(response)")
+				print("----------------------------------")
+			} catch {
+				Logger.debug(error: error, message: "InformationViewModel -postLikeState()")
+			}
+		}
 	}
 	
 }

--- a/Projects/FeatureInformation/Scene/InformationViewModel.swift
+++ b/Projects/FeatureInformation/Scene/InformationViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import SwiftUI
-import Combine
 import Core
 
 final class InformationViewModel: ObservableObject {
@@ -16,8 +15,6 @@ final class InformationViewModel: ObservableObject {
 	let userId: Int = 1578568449
 	let maHolyRepo: DefaultMakgeolliRepository
 	let userRepo: DefaultUserRepository
-	
-	private var cancellables: Set<AnyCancellable> = []
 	
 	init(makHolyId: Int, maHolyRepo: DefaultMakgeolliRepository, userRepo: DefaultUserRepository) {
 		self.makHolyId = 1


### PR DESCRIPTION
## Motivation
- issue number : 
#65 

## Changes
- EvaluateMakRequest
- EvaluateMakResponse 
- postLikeState 구현
- 버튼 누르면 LikeState 변하고 현재 LikeState에 따라 서버에 post 요청하는 방식으로 구현했습니다.

## Screen Shots
|기능|스크린샷|
|:--:|:--:|
|postLikeState| ![Simulator Screen Recording - iPhone 15 - 2023-11-10 at 09 53 30](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-1010/assets/77574120/f449fa7f-ddd5-4760-9400-507ebfb74710) |

## To Reviewers
- 유저 Id 랑 막걸리 Id 연결을 못했고, 일단 상수처럼 넣어서 구현 중입니다. 
