### PR TITLE
#73/MakHoly MyReaction 타입 분리

### DIFF
--- a/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
+++ b/Projects/Core/Sources/Models/MakHoly/MakHoly.swift
@@ -27,8 +27,7 @@ public struct MakHoly: Identifiable, Hashable {
 		ingredients: String,
 		description: String,
 		brewery: Brewery,
-		awards: [Award],
-		myReaction: MyReaction) {
+		awards: [Award]) {
 			self.id = id
 			self.name = name
 			self.imageId = imageId
@@ -38,7 +37,6 @@ public struct MakHoly: Identifiable, Hashable {
 			self.description = description
 			self.brewery = brewery
 			self.awards = awards
-			self.myReaction = myReaction
 		}
 	
 	public init() {
@@ -51,8 +49,7 @@ public struct MakHoly: Identifiable, Hashable {
 			ingredients: "",
 			description: "",
 			brewery: Brewery(),
-			awards: [],
-			myReaction: MyReaction())
+			awards: [])
 	}
 	
 	//mokData Initializer
@@ -90,8 +87,4 @@ public struct MakHoly: Identifiable, Hashable {
 	public let brewery: Brewery
 	/// 수상 배열
 	public let awards: [Award]
-	
-	// 나의 Reaction : 북마크, 평가, 코멘트
-	public var myReaction: MyReaction
-	
 }

--- a/Projects/Core/Sources/Network/Response/MakInfo/DetailResponse.swift
+++ b/Projects/Core/Sources/Network/Response/MakInfo/DetailResponse.swift
@@ -22,7 +22,7 @@ public struct DetailResult: Codable {
 	public let attributes: [DetailAttribute]?
 	public let userAction: UserAction?
 	
-	public var toEntity: MakHoly {
+	public func toEntity() -> (MakHoly, MyReaction) {
 		
 		let id = makSeq ?? -1
 		let name = makName ?? ""
@@ -38,7 +38,7 @@ public struct DetailResult: Codable {
 		
 		let myReaction = userAction?.toEnity ?? MyReaction()
 		
-		return MakHoly(
+		return (MakHoly(
 			id: id,
 			name: name,
 			imageId: imageId,
@@ -47,8 +47,8 @@ public struct DetailResult: Codable {
 			ingredients: ingredients,
 			description: description,
 			brewery: brewery,
-			awards: awards,
-			myReaction: myReaction)
+			awards: awards),
+				myReaction)
 	}
 	
 }
@@ -71,12 +71,12 @@ public struct UserAction: Codable {
 		
 		if isInMyComment == "Y",
 		let commentId = commentId,
-		let commentId = commentContents,
+		let commentContents = commentContents,
 		let date = writeDate{
 			comment = MyComment(
 				id: commentId,
 				isVisible: isCommentVisible == "Y" ? true : false ,
-				contents: commentId,
+				contents: commentContents,
 				date: date)
 		}
 		

--- a/Projects/Core/Sources/Repositories/MakgeolliRepository.swift
+++ b/Projects/Core/Sources/Repositories/MakgeolliRepository.swift
@@ -12,7 +12,7 @@ import Utils
 public protocol MakgeolliRepository {
 	func fetchFindByFeatures(sort: String?, offset: Int?,
 							 category: [String]?) async throws -> FindByFeaturesResponse
-	func fetchDetail(makNumber: Int, userId: Int) async throws -> MakHoly
+	func fetchDetail(makNumber: Int, userId: Int) async throws -> (MakHoly, MyReaction)
 	func fetchMakLikesAndComments(
 		makNumber: Int) async throws -> (LikeDetail, [VisibleComment])
 }
@@ -21,7 +21,7 @@ public final class DefaultMakgeolliRepository: MakgeolliRepository {
 	public init() { }
 	
 	/// 서버에서 막걸리 정보 가져오기
-	public func fetchDetail(makNumber: Int, userId: Int) async throws -> MakHoly {
+	public func fetchDetail(makNumber: Int, userId: Int) async throws -> (MakHoly, MyReaction) {
 		let request: [String: Any] = try DetailRequest(makNumber: makNumber, userId: userId).asDictionary()
 		
 		let response = try await MakgeolliAPI.request(
@@ -30,9 +30,9 @@ public final class DefaultMakgeolliRepository: MakgeolliRepository {
 		)
 		
 		if let result = response.result {
-			return result.toEntity
+			return result.toEntity()
 		}
-		return MakHoly()
+		return (MakHoly(), MyReaction())
 	}
 	
 	public func fetchMakLikesAndComments(makNumber: Int) async throws -> (LikeDetail, [VisibleComment]) {

--- a/Projects/FeatureInformation/Scene/InformationCardView/InfoLikeView.swift
+++ b/Projects/FeatureInformation/Scene/InformationCardView/InfoLikeView.swift
@@ -31,7 +31,7 @@ extension InfoLikeView {
 			ZStack{
 				RoundedRectangle(cornerRadius: 12)
 					.frame(height: 50)
-					.foregroundColor(viewModel.makHoly.myReaction.likeState == .like ? .GoldenYellow : .W10)
+					.foregroundColor(viewModel.myReaction.likeState == .like ? .GoldenYellow : .W10)
 				
 				HStack(spacing: 4) {
 					Image(systemName: "hand.thumbsup.fill")
@@ -39,7 +39,7 @@ extension InfoLikeView {
 					Text("좋았어요")
 						.SF17R()
 				}
-				.foregroundColor(viewModel.makHoly.myReaction.likeState == .like ? .white : .W85)
+				.foregroundColor(viewModel.myReaction.likeState == .like ? .white : .W85)
 			}
 		})
 		
@@ -53,7 +53,7 @@ extension InfoLikeView {
 			ZStack{
 				RoundedRectangle(cornerRadius: 12)
 					.frame(height: 50)
-					.foregroundColor(viewModel.makHoly.myReaction.likeState == .dislike ? .Lilac : .W10)
+					.foregroundColor(viewModel.myReaction.likeState == .dislike ? .Lilac : .W10)
 				
 				HStack(spacing: 4) {
 					Image(systemName: "hand.thumbsdown.fill")
@@ -62,7 +62,7 @@ extension InfoLikeView {
 						.SF17R()
 				}
 				.font(.style(.SF17R))
-				.foregroundColor(viewModel.makHoly.myReaction.likeState == .dislike ? .white : .W85)
+				.foregroundColor(viewModel.myReaction.likeState == .dislike ? .white : .W85)
 			}
 		})
 	}

--- a/Projects/FeatureInformation/Scene/InformationCardView/InfoMyCommentView.swift
+++ b/Projects/FeatureInformation/Scene/InformationCardView/InfoMyCommentView.swift
@@ -20,7 +20,7 @@ struct InfoMyCommentView: View {
 			
 			contentView()
 			
-			if let data = viewModel.makHoly.myReaction.comment?.date {
+			if let data = viewModel.myReaction.comment?.date {
 				footerView(date: data)
 			}
 			
@@ -40,7 +40,7 @@ extension InfoMyCommentView {
 			
 			Spacer()
 			
-			if let myComment = viewModel.makHoly.myReaction.comment {
+			if let myComment = viewModel.myReaction.comment {
 				Button(action: {
 					
 					viewModel.toggleCommentVisible()
@@ -70,11 +70,11 @@ extension InfoMyCommentView {
 			
 		} label: {
 			
-			let contents = viewModel.makHoly.myReaction.comment?.contents ?? "터치해서 코멘트를 남겨보세요!"
+			let contents = viewModel.myReaction.comment?.contents ?? "터치해서 코멘트를 남겨보세요!"
 			
 			Text(contents)
 				.font(.style(.SF14R))
-				.foregroundColor(Color(uiColor: viewModel.makHoly.myReaction.comment != nil ? .designSystem(.white)! : .designSystem(.w85)!))
+				.foregroundColor(Color(uiColor: viewModel.myReaction.comment != nil ? .designSystem(.white)! : .designSystem(.w85)!))
 				.frame(maxWidth: .infinity)
 				.multilineTextAlignment(.leading)
 				.lineLimit(nil)
@@ -84,7 +84,7 @@ extension InfoMyCommentView {
 						.foregroundColor(Color(uiColor: .designSystem(.w10)!))
 				)
 		}
-		.disabled(viewModel.makHoly.myReaction.comment != nil )
+		.disabled(viewModel.myReaction.comment != nil )
 	}
 	
 	func footerView(date: String) -> some View {

--- a/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoCommentsListView.swift
+++ b/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoCommentsListView.swift
@@ -21,6 +21,7 @@ struct InfoCommentsListView: View {
 				}, label: {
 					noReactionSingleView()
 				})
+				.padding(.leading, 16)
 			} else {
 				HStack(spacing: 16) {
 					

--- a/Projects/FeatureInformation/Scene/InformationViewModel.swift
+++ b/Projects/FeatureInformation/Scene/InformationViewModel.swift
@@ -24,11 +24,14 @@ final class InformationViewModel: ObservableObject {
 	
 	@Published var isFetchCompleted: Bool = false
 	@Published var makHoly: MakHoly = MakHoly()
+	@Published var myReaction: MyReaction = MyReaction()
 	@Published var likeDetail: LikeDetail = LikeDetail()
 	@Published var comments: [VisibleComment] = []
 	
 	@Published var showActionSheet: Bool = false
 	@Published var showCommentSheet: Bool = false
+	
+	@Published var commentText: String = ""
 	
 	private var user: User = User.user1
 	
@@ -58,10 +61,13 @@ final class InformationViewModel: ObservableObject {
 		Task {
 			
 			do {
-				let makHoly = try await maHolyRepo.fetchDetail(makNumber: self.makHolyId, userId: self.userId)
-				self.makHoly = makHoly
-				print("fetchMakHoly Completed : ------- \n \(makHoly) \n -------")
-				self.isFetchCompleted = true
+				let result = try await maHolyRepo.fetchDetail(makNumber: self.makHolyId, userId: self.userId)
+				self.makHoly = result.0
+				self.myReaction = result.1
+				print("fetchMakHoly Completed : -------")
+				print("makHoly : \(makHoly)")
+				print("myReaction : \(myReaction)")
+				print("----------------------------------")
 			} catch {
 				Logger.debug(error: error, message: "InformationViewModel -fetchMakHoly()")
 			}
@@ -92,29 +98,29 @@ final class InformationViewModel: ObservableObject {
 	// Comment Visibe 변경
 	func toggleCommentVisible() {
 		
-		self.makHoly.myReaction.comment?.isVisible.toggle()
+		self.myReaction.comment?.isVisible.toggle()
 		
 		// Comment Visible 업데이트 API 연결
 	}
 	
 	func likeButtonTapped() {
 		
-		switch self.makHoly.myReaction.likeState {
+		switch self.myReaction.likeState {
 		case .like:
-			self.makHoly.myReaction.likeState = .none
+			self.myReaction.likeState = .none
 		default:
-			self.makHoly.myReaction.likeState = .like
+			self.myReaction.likeState = .like
 		}
 		
 	}
 	
 	func dislikeButtonTapped() {
 		
-		switch self.makHoly.myReaction.likeState {
+		switch self.myReaction.likeState {
 		case .dislike:
-			self.makHoly.myReaction.likeState = .none
+			self.myReaction.likeState = .none
 		default:
-			self.makHoly.myReaction.likeState = .dislike
+			self.myReaction.likeState = .dislike
 		}
 		
 	}
@@ -126,7 +132,7 @@ final class InformationViewModel: ObservableObject {
 				let response = try await userRepo.evaluateMak(EvaluateMakRequest(
 					userId: self.userId,
 					makNumber: self.makHolyId,
-					likeState: self.makHoly.myReaction.likeState))
+					likeState: self.myReaction.likeState))
 				print("postLikeState Completed : -------")
 				print("response : \(response)")
 				print("----------------------------------")


### PR DESCRIPTION
## Motivation
- issue number : 
- #73 

## Changes
- MakHoly 와 MyReaction 정보를 분리했습니다. 
- Response 타입 관점에서는  DetailResult의 userAction와 나머지를 분리  
- #68 구현하다가 MyReaction 타입 관련한 수정 로직이 많아서 따로 분리했습니다. 
- 코멘트 로직 구현하다가 분리했는데 코멘트 API 벡엔드 오류 있어 이것만 일단 올려 둘게요
 

## To Reviewers
- dev_cyndi 만괂부
