### PR TITLE
#76/InfoLikeCommentDetailView 구현

### DIFF
--- a/Projects/Core/Sources/Network/Response/MakInfo/MakLikesAndCommentsResponse.swift
+++ b/Projects/Core/Sources/Network/Response/MakInfo/MakLikesAndCommentsResponse.swift
@@ -15,19 +15,31 @@ public struct MakLikesAndCommentsResponse: Codable {
 }
 
 public struct MakLikesAndCommentsResult: Codable {
-	public let makEvaluateInfo: MakEvaluateInfo?
-	public let comments: [VisibleCommentResponse]?
+	public let content: [MakLikeCommentContent]?
 	public let pageableInfo: PageableInfo?
 	
 	// TODO: pageableInfo 로직
 	public func toEntity() -> (LikeDetail, [VisibleComment]) {
-		let likeDetail = makEvaluateInfo?.toEntity ?? LikeDetail()
 		
+		if let content = content?[0] {
+			let result = content
+			return (result.toEntity())
+		}
+		
+		return (LikeDetail(), [])
+	}
+}
+
+public struct MakLikeCommentContent: Codable {
+	public let makEvaluateInfo: MakEvaluateInfo?
+	public let comments : [VisibleCommentResponse]?
+	
+	public func toEntity() -> (LikeDetail, [VisibleComment]) {
+		let likeDetail = makEvaluateInfo?.toEntity ?? LikeDetail()
 		var visibleComments: [VisibleComment] = []
 		if let comments = comments {
 			visibleComments = comments.compactMap { $0.toEntity }
 		}
-		
 		return (likeDetail, visibleComments)
 	}
 }

--- a/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentDetailView.swift
+++ b/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentDetailView.swift
@@ -15,24 +15,38 @@ struct InfoLikeCommentDetailView: View {
 	let comments: [VisibleComment]
 	let makHolyName: String
     var body: some View {
-		VStack {
-			// Header
-			headerView()
-				.padding(.top, 15)
-			// 내용 ListView
-			ScrollView(showsIndicators: false) {
-				VStack(spacing: 0) {
-					HStack {
-						Text("\(comments.count)개의 코멘트가 있어요")
-						Spacer()
-					}
-					ForEach(comments) { comment in
-						reactionSingleView(comment: comment)
-					}
-				}
-				.padding(.horizontal, 16)
-			}
+		
+		ZStack {
 			
+			Color.DarkGrey.ignoresSafeArea()
+			
+			VStack {
+				// Header
+				headerView()
+					.padding(.top, 15)
+				// 내용 ListView
+				ScrollView(showsIndicators: false) {
+					VStack(spacing: 0) {
+						HStack {
+							Text("\(comments.count)개의 코멘트가 있어요")
+								.SF12R()
+								.foregroundColor(.W50)
+							Spacer()
+						}
+						.padding(.top, 16)
+						.padding(.bottom, 6)
+						ForEach(comments) { comment in
+							reactionSingleView(comment: comment)
+								.padding(.vertical, 10)
+							if comment != comments.last {
+								Divider()
+							}
+						}
+					}
+					.padding(.horizontal, 16)
+				}
+				
+			}
 		}
     }
 }
@@ -97,7 +111,7 @@ extension InfoLikeCommentDetailView {
 				
 				Spacer()
 				
-				Text(makHolyName)
+				Text(comment.userName)
 					.SF14R()
 					.foregroundColor(.W25)
 			}

--- a/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentDetailView.swift
+++ b/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentDetailView.swift
@@ -1,0 +1,130 @@
+//
+//  InfoLikeCommentDetailView.swift
+//  FeatureInformation
+//
+//  Created by Eric Lee on 11/10/23.
+//  Copyright © 2023 com.tenten. All rights reserved.
+//
+
+import SwiftUI
+import Core
+
+struct InfoLikeCommentDetailView: View {
+	@Binding public var isPresented: Bool
+	
+	let comments: [VisibleComment] = [
+		VisibleComment(userName: "나", isLiked: .like, content: "와 즁말 맛있다", date: "10월 28일"),
+		VisibleComment(userName: "너", isLiked: .dislike, content: "와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어", date: "10월 28일"),
+		VisibleComment(userName: "이이이이이이이이름", isLiked: .dislike, content: "와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어", date: "10월 28일")
+	]
+	let makHolyName: String
+    var body: some View {
+		VStack {
+			// Header
+			headerView()
+				.padding(.top, 15)
+			// 내용 ListView
+			ScrollView(showsIndicators: false) {
+				VStack(spacing: 0) {
+					HStack {
+						Text("\(comments.count)개의 코멘트가 있어요")
+						Spacer()
+					}
+					ForEach(comments) { comment in
+						reactionSingleView(comment: comment)
+					}
+				}
+				.padding(.horizontal, 16)
+			}
+			
+		}
+    }
+}
+
+extension InfoLikeCommentDetailView {
+	@ViewBuilder
+	func headerView() -> some View {
+		VStack(spacing: 0) {
+			HStack(alignment: .center) {
+				
+				Button {
+					isPresented = false
+				} label: {
+					Text("취소")
+						.SF17R()
+						.foregroundColor(.Primary)
+				}
+				
+				Spacer()
+				
+				Text("평가 및 코멘트")
+					.SF17B()
+					.foregroundColor(.White)
+				
+				Spacer()
+				
+				Button {
+				
+				} label: {
+					Text("취소")
+						.SF17R()
+						.foregroundColor(.Primary)
+				}
+				.opacity(0)
+				
+			}
+			.padding(.vertical, 8)
+			.padding(.horizontal, 16)
+			DividerView()
+		}
+	}
+	
+	@ViewBuilder
+	func reactionSingleView(comment: VisibleComment) -> some View {
+		VStack(alignment: .leading, spacing: 10) {
+			
+			// 상단 유저 이름 & 평가 아이콘
+			HStack(alignment: .center, spacing: 0) {
+				
+				Text(makHolyName)
+					.SF14R()
+					.foregroundColor(.White)
+					.padding(.trailing, 4)
+				
+				if comment.isLiked != .none {
+					Image(uiImage: (comment.isLiked == .like) ? .designSystem(.like)! : .designSystem(.sorry)!)
+						.resizable()
+						.scaledToFit()
+						.frame(width: 10, height: 10)
+				}
+				
+				
+				Spacer()
+				
+				Text(makHolyName)
+					.SF14R()
+					.foregroundColor(.W25)
+			}
+			
+			// 리뷰 내용
+			Text(comment.content)
+				.SF14R()
+				.foregroundColor(.W85)
+				.frame(maxWidth: .infinity, alignment: .leading)
+			
+			// 리뷰 작성 날짜
+			HStack {
+				Text(comment.date)
+					.SF14R()
+					.foregroundColor(.W50)
+				
+				Spacer()
+				
+			}
+		}
+		.frame(width: UIScreen.main.bounds.width - 32)
+		.padding(.vertical, 10)
+		
+	}
+
+}

--- a/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentDetailView.swift
+++ b/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentDetailView.swift
@@ -12,11 +12,7 @@ import Core
 struct InfoLikeCommentDetailView: View {
 	@Binding public var isPresented: Bool
 	
-	let comments: [VisibleComment] = [
-		VisibleComment(userName: "나", isLiked: .like, content: "와 즁말 맛있다", date: "10월 28일"),
-		VisibleComment(userName: "너", isLiked: .dislike, content: "와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어", date: "10월 28일"),
-		VisibleComment(userName: "이이이이이이이이름", isLiked: .dislike, content: "와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어 와 좀 길게 작성하고 싶은데 냉탕에 상어가 살거라 믿었어", date: "10월 28일")
-	]
+	let comments: [VisibleComment]
 	let makHolyName: String
     var body: some View {
 		VStack {

--- a/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentView.swift
+++ b/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentView.swift
@@ -34,9 +34,6 @@ struct InfoLikeCommentView: View {
 					viewModel.showDetailCommentListSheet = true
 				}
 			}
-			.sheet(isPresented: $viewModel.showDetailCommentListSheet, content: {
-				InfoLikeCommentDetailView(isPresented: $viewModel.showDetailCommentListSheet, comments: viewModel.comments, makHolyName: viewModel.makHoly.name)
-			})
 			
 			InfoLikePercentageView(likeDetail: viewModel.likeDetail)
 				.padding(.bottom, 20)

--- a/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentView.swift
+++ b/Projects/FeatureInformation/Scene/InformationDetailView/InfoLikeCommentView/InfoLikeCommentView.swift
@@ -20,13 +20,23 @@ struct InfoLikeCommentView: View {
 				Text("평가 및 코멘트")
 					.SF20B()
 					.foregroundColor(.White)
-				Image(systemName: "chevron.right")
-					.font(.system(size: 20, weight: .bold))
-					.foregroundColor(.White)
+				if viewModel.comments.count > 1 {
+					Image(systemName: "chevron.right")
+						.font(.system(size: 20, weight: .bold))
+						.foregroundColor(.White)
+				}
 				Spacer()
 			}
 			.padding(.vertical, 20)
 			.padding(.horizontal, 16)
+			.onTapGesture {
+				if viewModel.comments.count > 1 {
+					viewModel.showDetailCommentListSheet = true
+				}
+			}
+			.sheet(isPresented: $viewModel.showDetailCommentListSheet, content: {
+				InfoLikeCommentDetailView(isPresented: $viewModel.showDetailCommentListSheet, comments: viewModel.comments, makHolyName: viewModel.makHoly.name)
+			})
 			
 			InfoLikePercentageView(likeDetail: viewModel.likeDetail)
 				.padding(.bottom, 20)

--- a/Projects/FeatureInformation/Scene/InformationView.swift
+++ b/Projects/FeatureInformation/Scene/InformationView.swift
@@ -54,6 +54,9 @@ public struct InformationView: View {
 		.actionSheet(isPresented: $viewModel.showActionSheet, content: {
 			ActionSheet(title: Text("Action Sheet title"))
 		})
+		.sheet(isPresented: $viewModel.showDetailCommentListSheet, content: {
+			InfoLikeCommentDetailView(isPresented: $viewModel.showDetailCommentListSheet, comments: viewModel.comments, makHolyName: viewModel.makHoly.name)
+		})
 	}
 }
 

--- a/Projects/FeatureInformation/Scene/InformationViewModel.swift
+++ b/Projects/FeatureInformation/Scene/InformationViewModel.swift
@@ -30,6 +30,7 @@ final class InformationViewModel: ObservableObject {
 	
 	@Published var showActionSheet: Bool = false
 	@Published var showCommentSheet: Bool = false
+	@Published var showDetailCommentListSheet: Bool = false
 	
 	@Published var commentText: String = ""
 	


### PR DESCRIPTION
## Motivation
- issue number : 
#76 
## Changes
- Infomration화면에서 코멘트 및 평가를 누르면 넘어가는 상세 모달창 화면을 구현했습니다.
- 막걸리 평가와 코멘트 API 수정이 있어 Result Response 타입 수정

## Screen Shots
|기능|스크린샷|
|:--:|:--:|
|InfoLikeCommentDetailView|![Simulator Screen Recording - iPhone 15 - 2023-11-13 at 11 56 49](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-1010/assets/77574120/83f1d331-5a80-47da-a436-af9daa0c6fd8)|
