### PR TITLE
#99/주룩 막걸리 이미지 그레이 스케일 적용

### DIFF
--- a/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
+++ b/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
@@ -14,6 +14,9 @@ public struct MakHolyImageView: View {
 	let imageId: String
 	let type: ImageType
 	let ratio: ImageRatioType
+
+    @State private var isFailingToLoad = false
+    
 	var imageURL: URL? {
 		let baseURL = "https://d2hyndjmu9mjcd.cloudfront.net/images/"
 		let urlString = "\(baseURL)\(imageId).png?\(self.type.query)&\(self.ratio.query)"
@@ -41,11 +44,15 @@ public struct MakHolyImageView: View {
 			.resizable()
 			.onFailure { error in
 				print("Image loading failed with error: \(error)")
+                isFailingToLoad = true
 			}
 			.onFailureImage(UIImage(named: "errorImage",
 									in: Bundle(identifier: "com.tenten.julookdesignsystem"),
-									with: nil))
+									with: nil)
+            
+            )
 			.scaledToFit()
 			.frame(width: self.type.size.width, height: self.type.size.height)
+            .grayscale(isFailingToLoad ? 1.0 : 0.0)
 	}
 }


### PR DESCRIPTION
## Motivation
- issue number : #99 

## Changes
- 로딩 실패시 주룩 막걸리 이미지 그레이스케일 적용

## Screen Shots
|기능|스크린샷|
|:--:|:--:|
|주룩 막걸리 이미지 그레이스케일|![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-1010/assets/44664457/4376c042-0e14-4127-8dc4-e6c8afb78eb0)|

## To Reviewers
- 아지, 에릭, 씬디
