### PR TITLE
#118/MakHolyImageView 개선

### DIFF
--- a/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
+++ b/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
@@ -17,7 +17,7 @@ public struct MakHolyImageView: View {
 	
 	var imageURL: URL? {
 		if let baseURL = Bundle.main.infoDictionary?["IMAGE_API_URL"] as? String {
-			let urlString = "\(baseURL)\(imageId).png?\(self.type.query)&\(self.ratio.query)"
+			let urlString = "\(baseURL)\(imageId).webp"
 			return URL(string: urlString)
 		}
 		return nil

--- a/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
+++ b/Projects/Core/Sources/Common/Componets/MakHolyImageView.swift
@@ -14,6 +14,7 @@ public struct MakHolyImageView: View {
 	let imageId: String
 	let type: ImageType
 	let ratio: ImageRatioType
+	private let cacheLifeTimeDuration: StorageExpiration = .days(14)
 	
 	var imageURL: URL? {
 		if let baseURL = Bundle.main.infoDictionary?["IMAGE_API_URL"] as? String {
@@ -37,10 +38,11 @@ public struct MakHolyImageView: View {
 			.placeholder {
 				ProgressView()
 			}
-			.loadDiskFileSynchronously()
-			.cacheMemoryOnly()
+			.loadDiskFileSynchronously(false)
+			.cancelOnDisappear(true)
+			.memoryCacheExpiration(cacheLifeTimeDuration)
+			.diskCacheExpiration(cacheLifeTimeDuration)
 			.fade(duration: 0.15)
-			.retry(maxCount: 2, interval: .seconds(3))
 			.resizable()
 			.onFailureImage(.designSystem(.errorImage)!)
 			.scaledToFit()


### PR DESCRIPTION
## Motivation
- issue number : 
#118 

## Changes
- 이미지 url - webp 형식으로, 사진 크기 설정 안하고 기본으로 가져오기
- 기타 설정들 : 캐시되는 기간, 디스크 캐싱등
- retry 삭제

## To Reviewers
- 원래 기본 설정이 디스크 캐싱 되는 거고 .cacheMemoryOnly() 이걸 추가하면 메모리에만 캐싱되는 거였네요 
- s3 무료 횟수는 아무래도 제가 Flex 한것 같네요 💸 ㅎㅎㅎㅎㅎㅎ